### PR TITLE
Fix canonical word order if one partition is maxed out

### DIFF
--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -267,8 +267,6 @@ get_time_successor(const CanonicalABWord<Location, ConstraintSymbolType> &word,
 	}
 	// All the elements between last_nonmax_partition  and the last Abs_i are
 	// copied without modification.
-	// TODO(morxa) Isn't this the wrong order of the elements after and before last_nonmax?
-	std::reverse_copy(std::rbegin(word), last_nonmax_partition, std::back_inserter(res));
 	// Process all Abs_i before last_nonmax_partition.
 	if (std::prev(std::rend(word)) != last_nonmax_partition) {
 		// The first set needs to be incremented if its region indexes are even.
@@ -282,6 +280,7 @@ get_time_successor(const CanonicalABWord<Location, ConstraintSymbolType> &word,
 		                  std::prev(word.rend()),
 		                  std::back_inserter(res));
 	}
+	std::reverse_copy(std::rbegin(word), last_nonmax_partition, std::back_inserter(res));
 	if (!maxed.empty()) {
 		res.push_back(std::move(maxed));
 	}

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -189,18 +189,18 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	        {{TARegionState{Location{"s0"}, "c1", 2}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 3)
 	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}}}));
-	//	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
-	//	                                          {TARegionState{Location{"s0"}, "c1", 1}},
-	//	                                          {TARegionState{Location{"s0"}, "c2", 2}}}),
-	//	                         3)
-	//	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c2", 3}},
-	//	                          {TARegionState{Location{"s0"}, "c0", 1}},
-	//	                          {TARegionState{Location{"s0"}, "c1", 1}}}));
-	// CHECK(get_time_successor(
-	//        CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
-	//        {TARegionState{Location{"s0"}, "c1", 2}}}), 3)
-	//      == CanonicalABWord({{TARegionState{Location{"s0"}, "c1", 3}},
-	//      {TARegionState{Location{"s0"}, "c0", 1}}}));
+	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
+	                                          {TARegionState{Location{"s0"}, "c1", 1}},
+	                                          {TARegionState{Location{"s0"}, "c2", 3}}}),
+	                         3)
+	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c2", 4}},
+	                          {TARegionState{Location{"s0"}, "c0", 1}},
+	                          {TARegionState{Location{"s0"}, "c1", 1}}}));
+	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
+	                                          {TARegionState{Location{"s0"}, "c1", 3}}}),
+	                         3)
+	      == CanonicalABWord(
+	        {{TARegionState{Location{"s0"}, "c1", 4}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
 	                                          {TARegionState{Location{"s0"}, "c1", 1}}}),
 	                         3)
@@ -208,34 +208,27 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	        {{TARegionState{Location{"s0"}, "c1", 2}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
 	const logic::AtomicProposition<std::string> a{"a"};
 	const logic::AtomicProposition<std::string> b{"b"};
-	// CHECK(get_time_successor(CanonicalABWord({{ATARegionState{a, 0}},
-	//                                          {ATARegionState{b, 1}},
-	//                                          {ATARegionState{a || b, 2}}}),
-	//                         3)
-	//      == CanonicalABWord(
-	//        {{ATARegionState{a || b, 3}}, {ATARegionState{a, 1}}, {ATARegionState{b, 1}}}));
+	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{a, 0}},
+	                                          {ATARegionState{b, 1}},
+	                                          {ATARegionState{a || b, 3}}}),
+	                         3)
+	      == CanonicalABWord(
+	        {{ATARegionState{a || b, 4}}, {ATARegionState{a, 1}}, {ATARegionState{b, 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{a, 7}}}), 3)
 	      == CanonicalABWord({{ATARegionState{a, 7}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 3}}, {ATARegionState{a, 7}}}), 3)
 	      == CanonicalABWord({{ATARegionState{b, 4}}, {ATARegionState{a, 7}}}));
 
-	// TODO fails because only the first region index is incremented, resulting in an invalid word
-	// CHECK(
-	//  get_time_successor(CanonicalABWord(
-	//                       {{ATARegionState{b, 3}, ATARegionState{a,
-	//                       7}}}),
-	//                     3)
-	//  == CanonicalABWord(
-	//    {{ATARegionState{b, 4}, ATARegionState{a, 7}}}));
+	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 3}, ATARegionState{a, 7}}}), 3)
+	      == CanonicalABWord({{ATARegionState{b, 4}}, {ATARegionState{a, 7}}}));
 
-	// CHECK(
-	//  get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 3}},
-	//                                      {TARegionState{"s1", "c0", 4}},
-	//                                      {ATARegionState{a, 7}}}),
-	//                     3)
-	//  == CanonicalABWord(
-	//    {{TARegionState{"s1", "c0", 5}}, {ATARegionState{a, 7}}, {TARegionState{Location{"s0"},
-	//    "c0", 3}}}));
+	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s1"}, "c0", 4}},
+	                                          {TARegionState{Location{"s0"}, "c0", 3}},
+	                                          {ATARegionState{a, 7}}}),
+	                         3)
+	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 4}},
+	                          {TARegionState{Location{"s1"}, "c0", 5}},
+	                          {ATARegionState{a, 7}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 1}, ATARegionState{a, 3}}}), 3)
 	      == CanonicalABWord({{ATARegionState{b, 2}, ATARegionState{a, 4}}}));
 	CHECK(get_time_successor(

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -235,6 +235,14 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	        CanonicalABWord({{TARegionState{Location{"l0"}, "x", 1}, ATARegionState{a, 5}}}), 2)
 	      == CanonicalABWord({{TARegionState{Location{"l0"}, "x", 2}}, {ATARegionState{a, 5}}}));
 
+	CHECK(get_time_successor(CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 0}},
+	                                         {TARegionState{Location{"l0"}, "x1", 1}},
+	                                         {TARegionState{Location{"l0"}, "x3", 3}}},
+	                         1)
+	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x1", 2}},
+	                         {TARegionState{Location{"l0"}, "x0", 1}},
+	                         {TARegionState{Location{"l0"}, "x3", 3}}});
+
 	// Successor of successor.
 	CHECK(get_time_successor(
 	        get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 3), 3)


### PR DESCRIPTION
This fixes a bug where a partition with only maxed out regions would be inserted in the middle instead of the end of the word, resulting in exceptions during search.

As an example, consider
```
CanonicalABWord{
  {TARegionState{Location{"l0"}, "x0", 0}},
  {TARegionState{Location{"l0"}, "x1", 1}},
  {TARegionState{Location{"l0"}, "x3", 3}}}
```
Previously, the successor of the word was computed as
```
CanonicalABWord{
  {TARegionState{Location{"l0"}, "x1", 2}},
  {TARegionState{Location{"l0"}, "x3", 3}}},
  {TARegionState{Location{"l0"}, "x0", 1}}
```
This PR fixes the order to:
```
CanonicalABWord{
  {TARegionState{Location{"l0"}, "x1", 2}},
  {TARegionState{Location{"l0"}, "x0", 1}},
  {TARegionState{Location{"l0"}, "x3", 3}}}
```