### PR TITLE
Extend benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
     steps:
       - run:
           name: Build the project
-          command: cmake -B build -DBUILD_BENCHMARKS=ON && cmake --build build -j$(nproc)
+          command: cmake -B build -DBUILD_BENCHMARKS=ON && cmake --build build -j $(($(nproc)/8))
   test:
     steps:
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,13 @@ add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+
+find_package(fmt REQUIRED)
+
 if (COVERAGE)
-  include(CodeCoverage)
-  append_coverage_compiler_flags()
-endif()
+	include(CodeCoverage)
+	append_coverage_compiler_flags()
+endif ()
 
 add_subdirectory(src)
 add_subdirectory(third_party)

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -194,6 +194,7 @@ Launcher::run()
 	                          create_heuristic(heuristic));
 	SPDLOG_INFO("Running search {}", multi_threaded ? "multi-threaded" : "single-threaded");
 	search.build_tree(multi_threaded);
+	search.label();
 	SPDLOG_INFO("Search complete!");
 	SPDLOG_TRACE("Search tree:\n{}", search::node_to_string(*search.get_root(), true));
 	if (!tree_dot_graph.empty()) {

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -252,14 +252,25 @@ public:
 			return;
 		}
 		for (const auto &child : existing_children) {
+			SPDLOG_TRACE("Found existing node for {}", fmt::ptr(child));
 			if (child->label == NodeLabel::CANCELED) {
 				SPDLOG_DEBUG("Expansion of {}: Found existing child {}, is canceled, re-adding",
 				             fmt::ptr(node),
 				             fmt::ptr(child));
 				child->reset_label();
 				add_node_to_queue(child);
-			} else {
-				SPDLOG_TRACE("Found existing node for {}", fmt::ptr(child));
+			} else if (dominates_ancestor(node)) {
+				// If we have a loop, this node may be dominating itself, but we can find that out only
+				// after adding an existing child. Therefore, check again for monotonic domination.
+				node->label_reason = LabelReason::MONOTONIC_DOMINATION;
+				node->state        = NodeState::GOOD;
+				node->is_expanded  = true;
+				node->is_expanding = false;
+				if (incremental_labeling_) {
+					node->set_label(NodeLabel::TOP, terminate_early_);
+					node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
+				}
+				return;
 			}
 		}
 		if (incremental_labeling_ && !existing_children.empty()) {

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -251,6 +251,19 @@ public:
 			// The node has been canceled in the meantime, do not add children to queue.
 			return;
 		}
+		if (!existing_children.empty() && dominates_ancestor(node)) {
+			// If we have a loop, this node may be dominating itself, but we can find that out only
+			// after adding an existing child. Therefore, check again for monotonic domination.
+			node->label_reason = LabelReason::MONOTONIC_DOMINATION;
+			node->state        = NodeState::GOOD;
+			node->is_expanded  = true;
+			node->is_expanding = false;
+			if (incremental_labeling_) {
+				node->set_label(NodeLabel::TOP, terminate_early_);
+				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
+			}
+			return;
+		}
 		for (const auto &child : existing_children) {
 			SPDLOG_TRACE("Found existing node for {}", fmt::ptr(child));
 			if (child->label == NodeLabel::CANCELED) {
@@ -259,18 +272,6 @@ public:
 				             fmt::ptr(child));
 				child->reset_label();
 				add_node_to_queue(child);
-			} else if (dominates_ancestor(node)) {
-				// If we have a loop, this node may be dominating itself, but we can find that out only
-				// after adding an existing child. Therefore, check again for monotonic domination.
-				node->label_reason = LabelReason::MONOTONIC_DOMINATION;
-				node->state        = NodeState::GOOD;
-				node->is_expanded  = true;
-				node->is_expanding = false;
-				if (incremental_labeling_) {
-					node->set_label(NodeLabel::TOP, terminate_early_);
-					node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
-				}
-				return;
 			}
 		}
 		if (incremental_labeling_ && !existing_children.empty()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,6 +142,9 @@ add_executable(test_xml_writer test_xml_writer.cpp)
 target_link_libraries(test_xml_writer PRIVATE utilities Catch2::Catch2WithMain)
 catch_discover_tests(test_xml_writer)
 
+add_executable(benchmark_conveyor_belt benchmark_conveyor_belt.cpp)
+target_link_libraries(benchmark_conveyor_belt PRIVATE fmt::fmt mtl_ata_translation search Catch2::Catch2WithMain)
+
 file(COPY data DESTINATION .)
 add_executable(test_app test_app.cpp)
 target_link_libraries(test_app PRIVATE app Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,7 +143,7 @@ target_link_libraries(test_xml_writer PRIVATE utilities Catch2::Catch2WithMain)
 catch_discover_tests(test_xml_writer)
 
 add_executable(benchmark_conveyor_belt benchmark_conveyor_belt.cpp)
-target_link_libraries(benchmark_conveyor_belt PRIVATE fmt::fmt mtl_ata_translation search Catch2::Catch2WithMain)
+target_link_libraries(benchmark_conveyor_belt PRIVATE fmt::fmt mtl_ata_translation search Catch2::Catch2WithMain visualization)
 
 file(COPY data DESTINATION .)
 add_executable(test_app test_app.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,9 +142,6 @@ add_executable(test_xml_writer test_xml_writer.cpp)
 target_link_libraries(test_xml_writer PRIVATE utilities Catch2::Catch2WithMain)
 catch_discover_tests(test_xml_writer)
 
-add_executable(benchmark_conveyor_belt benchmark_conveyor_belt.cpp)
-target_link_libraries(benchmark_conveyor_belt PRIVATE fmt::fmt mtl_ata_translation search Catch2::Catch2WithMain visualization)
-
 file(COPY data DESTINATION .)
 add_executable(test_app test_app.cpp)
 target_link_libraries(test_app PRIVATE app Catch2::Catch2WithMain)
@@ -175,7 +172,7 @@ if (BUILD_BENCHMARKS)
   set(BENCHMARK_ENABLE_TESTING OFF)
   FetchContent_MakeAvailable(googlebenchmark)
 
-  add_executable(tacos_benchmark benchmark.cpp benchmark_robot.cpp benchmark_railroad.cpp)
+  add_executable(tacos_benchmark benchmark.cpp benchmark_robot.cpp benchmark_railroad.cpp benchmark_conveyor_belt.cpp)
   target_link_libraries(tacos_benchmark PRIVATE railroad mtl_ata_translation search benchmark::benchmark)
 
 endif()

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -129,7 +129,8 @@ TEST_CASE("Conveyor belt", "[.benchmark]")
 	const unsigned int K = std::max(plant.get_largest_constant(), spec.get_largest_constant());
 	TreeSearch         search{
     &plant, &ata, controller_actions, environment_actions, K, true, true, generate_heuristic()};
-	search.build_tree(false);
+	search.build_tree(true);
+	search.label();
 	CHECK(search.get_root()->label == NodeLabel::TOP);
 	visualization::search_tree_to_graphviz(*search.get_root(), true)
 	  .render_to_file("conveyor_belt.svg");

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Conveyor belt", "[.benchmark]")
 {
 	Location l_no{"NO"};
 	Location l_st{"ST"};
-	Location l_op{"OP"};
+	// Location l_op{"OP"};
 	Location l_sp{"SP"};
 
 	std::set<std::string> environment_actions{"release", "resume", "stuck"};
@@ -100,17 +100,25 @@ TEST_CASE("Conveyor belt", "[.benchmark]")
 	               std::inserter(actions, std::begin(actions)));
 
 	// the conveyor belt plant
-	TA plant{{l_no, l_st, l_op, l_sp},
+	TA plant{{l_no,
+	          l_st,
+	          // l_op,
+	          l_sp},
 	         actions,
 	         l_no,
 	         {l_no},
-	         {"stop_timer"},
-	         {Transition{l_no, "move", l_no},
+	         {{"move_timer"}, "stop_timer"},
+	         {Transition{l_no,
+	                     "move",
+	                     l_no,
+	                     {{"move_timer",
+	                       automata::AtomicClockConstraintT<std::greater_equal<Time>>{1}}},
+	                     {"move_timer"}},
 	          Transition{l_no, "stuck", l_st},
 	          Transition{l_no, "stop", l_sp},
 	          Transition{l_st, "release", l_no},
-	          Transition{l_st, "release", l_op},
-	          Transition{l_op, "stop", l_sp},
+	          // Transition{l_st, "release", l_op},
+	          // Transition{l_op, "stop", l_sp},
 	          Transition{l_sp, "resume", l_no}}};
 
 	// the specification

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -47,7 +47,6 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 {
 	Location l_no{"NO"};
 	Location l_st{"ST"};
-	// Location l_op{"OP"};
 	Location l_sp{"SP"};
 
 	std::set<std::string> environment_actions{"release", "resume", "stuck"};
@@ -60,10 +59,7 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 	               std::inserter(actions, std::begin(actions)));
 
 	// the conveyor belt plant
-	TA plant{{l_no,
-	          l_st,
-	          // l_op,
-	          l_sp},
+	TA plant{{l_no, l_st, l_sp},
 	         actions,
 	         l_no,
 	         {l_no},
@@ -77,8 +73,6 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 	          Transition{l_no, "stuck", l_st, {}, {"stuck_timer"}},
 	          Transition{l_no, "stop", l_sp},
 	          Transition{l_st, "release", l_no},
-	          // Transition{l_st, "release", l_op},
-	          // Transition{l_op, "stop", l_sp},
 	          Transition{l_sp, "resume", l_no}}};
 
 	// the specification

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -121,7 +121,7 @@ TEST_CASE("Conveyor belt", "[benchmark]")
 	const auto stuck_f   = F{AP{"stuck"}};
 	const auto stop_f    = F{AP{"stop"}};
 	const auto resume_f  = F{AP{"resume"}};
-	F          spec{move_f.dual_until(!release_f)};
+	F          spec{move_f.dual_until(!release_f, logic::TimeInterval(0, 2))};
 
 	auto ata = mtl_ata_translation::translate(
 	  spec, {AP{"move"}, AP{"release"}, AP{"stuck"}, AP{"stop"}, AP{"resume"}});

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -95,9 +95,10 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 	  spec, {AP{"move"}, AP{"release"}, AP{"stuck"}, AP{"stop"}, AP{"resume"}});
 	const unsigned int K = std::max(plant.get_largest_constant(), spec.get_largest_constant());
 
-	std::size_t tree_size       = 0;
-	std::size_t controller_size = 0;
-	std::size_t plant_size      = 0;
+	std::size_t tree_size        = 0;
+	std::size_t pruned_tree_size = 0;
+	std::size_t controller_size  = 0;
+	std::size_t plant_size       = 0;
 
 	for (auto _ : state) {
 		std::unique_ptr<search::Heuristic<long, TreeSearch::Node>> heuristic;
@@ -140,13 +141,22 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 		                                                          environment_actions,
 		                                                          K);
 		tree_size += search.get_size();
+		std::for_each(std::begin(search.get_nodes()),
+		              std::end(search.get_nodes()),
+		              [&pruned_tree_size](const auto &node) {
+			              if (node.second->label != search::NodeLabel::CANCELED
+			                  && node.second->label != search::NodeLabel::UNLABELED) {
+				              pruned_tree_size += 1;
+			              }
+		              });
 		plant_size += plant.get_locations().size();
 		controller_size += controller.get_locations().size();
 	}
 
-	state.counters["tree_size"]       = tree_size;
-	state.counters["controller_size"] = controller_size;
-	state.counters["plant_size"]      = plant_size;
+	state.counters["tree_size"]        = tree_size;
+	state.counters["pruned_tree_size"] = pruned_tree_size;
+	state.counters["controller_size"]  = controller_size;
+	state.counters["plant_size"]       = plant_size;
 }
 
 BENCHMARK_CAPTURE(BM_ConveyorBelt, single_heuristic, false)->DenseRange(0, 5, 1)->UseRealTime();

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -30,10 +30,8 @@
 #include "search/search.h"
 #include "search/search_tree.h"
 #include "search/synchronous_product.h"
-#ifdef VISUALIZATION
-#	include "visualization/ta_to_graphviz.h"
-#	include "visualization/tree_to_graphviz.h"
-#endif
+#include "visualization/ta_to_graphviz.h"
+#include "visualization/tree_to_graphviz.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -85,7 +83,7 @@ generate_heuristic(long                  weight_canonical_words     = 0,
 	  std::move(heuristics));
 }
 
-TEST_CASE("Conveyor belt", "[benchmark]")
+TEST_CASE("Conveyor belt", "[.benchmark]")
 {
 	Location l_no{"NO"};
 	Location l_st{"ST"};
@@ -133,14 +131,12 @@ TEST_CASE("Conveyor belt", "[benchmark]")
     &plant, &ata, controller_actions, environment_actions, K, true, true, generate_heuristic()};
 	search.build_tree(false);
 	CHECK(search.get_root()->label == NodeLabel::TOP);
-#ifdef HAVE_VISUALIZATION
 	visualization::search_tree_to_graphviz(*search.get_root(), true)
-	  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
+	  .render_to_file("conveyor_belt.svg");
 	visualization::ta_to_graphviz(controller_synthesis::create_controller(
 	                                search.get_root(), controller_actions, environment_actions, 2),
 	                              false)
-	  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
-#endif
+	  .render_to_file("conveyor_belt_controller.svg");
 }
 
 } // namespace

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -119,7 +119,7 @@ TEST_CASE("Conveyor belt", "[.benchmark]")
 	const auto stuck_f   = F{AP{"stuck"}};
 	const auto stop_f    = F{AP{"stop"}};
 	const auto resume_f  = F{AP{"resume"}};
-	F          spec{move_f.dual_until(!release_f, logic::TimeInterval(0, 2))};
+	const auto spec      = finally(release_f && finally(move_f, logic::TimeInterval(0, 2)));
 
 	auto ata = mtl_ata_translation::translate(
 	  spec, {AP{"move"}, AP{"release"}, AP{"stuck"}, AP{"stop"}, AP{"resume"}});

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -1,0 +1,146 @@
+/***************************************************************************
+ *  benchmark_converyor_belt - case study with a simple conveyor belt model
+ *
+ *  Created: Mon 26 Jul 2021 20:06:42 CEST 13:00
+ *  Copyright  2021  Stefan Schupp <stefan.schupp@tuwien.ac.at>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "automata/automata.h"
+#include "automata/ta.h"
+#include "automata/ta_product.h"
+#include "automata/ta_regions.h"
+#include "mtl/MTLFormula.h"
+#include "mtl_ata_translation/translator.h"
+#include "railroad.h"
+#include "search/canonical_word.h"
+#include "search/create_controller.h"
+#include "search/heuristics.h"
+#include "search/search.h"
+#include "search/search_tree.h"
+#include "search/synchronous_product.h"
+#ifdef VISUALIZATION
+#	include "visualization/ta_to_graphviz.h"
+#	include "visualization/tree_to_graphviz.h"
+#endif
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <spdlog/common.h>
+#include <spdlog/spdlog.h>
+
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#undef TRUE
+
+namespace {
+
+using Location   = automata::ta::Location<std::string>;
+using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
+using Transition = automata::ta::Transition<std::string, std::string>;
+using automata::Time;
+using F  = logic::MTLFormula<std::string>;
+using AP = logic::AtomicProposition<std::string>;
+using search::NodeLabel;
+using TreeSearch = search::TreeSearch<std::string, std::string>;
+
+std::unique_ptr<search::Heuristic<long, search::SearchTreeNode<std::string, std::string>>>
+generate_heuristic(long                  weight_canonical_words     = 0,
+                   long                  weight_environment_actions = 0,
+                   std::set<std::string> environment_actions        = {},
+                   long                  weight_time_heuristic      = 1)
+{
+	using H = search::Heuristic<long, search::SearchTreeNode<std::string, std::string>>;
+	std::vector<std::pair<long, std::unique_ptr<H>>> heuristics;
+	heuristics.emplace_back(
+	  weight_canonical_words,
+	  std::make_unique<
+	    search::NumCanonicalWordsHeuristic<long,
+	                                       search::SearchTreeNode<std::string, std::string>>>());
+	heuristics.emplace_back(
+	  weight_environment_actions,
+	  std::make_unique<
+	    search::PreferEnvironmentActionHeuristic<long,
+	                                             search::SearchTreeNode<std::string, std::string>,
+	                                             std::string>>(environment_actions));
+	heuristics.emplace_back(
+	  weight_time_heuristic,
+	  std::make_unique<
+	    search::TimeHeuristic<long, search::SearchTreeNode<std::string, std::string>>>());
+	return std::make_unique<
+	  search::CompositeHeuristic<long, search::SearchTreeNode<std::string, std::string>>>(
+	  std::move(heuristics));
+}
+
+TEST_CASE("Conveyor belt", "[benchmark]")
+{
+	Location l_no{"NO"};
+	Location l_st{"ST"};
+	Location l_op{"OP"};
+	Location l_sp{"SP"};
+
+	std::set<std::string> environment_actions{"release", "resume", "stuck"};
+	std::set<std::string> controller_actions{"move", "stop"};
+	std::set<std::string> actions;
+	std::set_union(std::begin(environment_actions),
+	               std::end(environment_actions),
+	               std::begin(controller_actions),
+	               std::end(controller_actions),
+	               std::inserter(actions, std::begin(actions)));
+
+	// the conveyor belt plant
+	TA plant{{l_no, l_st, l_op, l_sp},
+	         actions,
+	         l_no,
+	         {l_no},
+	         {"stop_timer"},
+	         {Transition{l_no, "move", l_no},
+	          Transition{l_no, "stuck", l_st},
+	          Transition{l_no, "stop", l_sp},
+	          Transition{l_st, "release", l_no},
+	          Transition{l_st, "release", l_op},
+	          Transition{l_op, "stop", l_sp},
+	          Transition{l_sp, "resume", l_no}}};
+
+	// the specification
+	const auto move_f    = F{AP{"move"}};
+	const auto release_f = F{AP{"release"}};
+	const auto stuck_f   = F{AP{"stuck"}};
+	const auto stop_f    = F{AP{"stop"}};
+	const auto resume_f  = F{AP{"resume"}};
+	F          spec{move_f.dual_until(!release_f)};
+
+	auto ata = mtl_ata_translation::translate(
+	  spec, {AP{"move"}, AP{"release"}, AP{"stuck"}, AP{"stop"}, AP{"resume"}});
+	CAPTURE(spec);
+	CAPTURE(plant);
+	CAPTURE(ata);
+	const unsigned int K = std::max(plant.get_largest_constant(), spec.get_largest_constant());
+	TreeSearch         search{
+    &plant, &ata, controller_actions, environment_actions, K, true, true, generate_heuristic()};
+	search.build_tree(false);
+	CHECK(search.get_root()->label == NodeLabel::TOP);
+#ifdef HAVE_VISUALIZATION
+	visualization::search_tree_to_graphviz(*search.get_root(), true)
+	  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
+	visualization::ta_to_graphviz(controller_synthesis::create_controller(
+	                                search.get_root(), controller_actions, environment_actions, 2),
+	                              false)
+	  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
+#endif
+}
+
+} // namespace

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -167,7 +167,7 @@ BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
   ->ArgsProduct({benchmark::CreateRange(1, 8, 2), benchmark::CreateRange(1, 8, 2), {0}})
   ->UseRealTime();
 BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
-  ->ArgsProduct({benchmark::CreateRange(1, 4, 2),
-                 benchmark::CreateRange(1, 4, 2),
-                 benchmark::CreateRange(1, 4, 2)})
+  ->ArgsProduct({benchmark::CreateRange(1, 2, 2),
+                 benchmark::CreateRange(1, 2, 2),
+                 benchmark::CreateRange(1, 2, 2)})
   ->UseRealTime();

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -126,6 +126,7 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 		  &plant, &ata, controller_actions, environment_actions, K, true, true, std::move(heuristic)};
 
 		search.build_tree(multi_threaded);
+		search.label();
 		plant_size += plant.get_locations().size();
 		tree_size += search.get_size();
 		auto controller = controller_synthesis::create_controller(

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -141,12 +141,11 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 // Range all over all heuristics individually.
 BENCHMARK_CAPTURE(BM_Railroad, single_heuristic, Mode::SIMPLE)->DenseRange(0, 5, 1)->UseRealTime();
 // Single-threaded.
-BENCHMARK_CAPTURE(BM_Railroad, signle_heuristic_single_threaded, Mode::SIMPLE, false)
+BENCHMARK_CAPTURE(BM_Railroad, single_heuristic_single_thread, Mode::SIMPLE, false)
   ->DenseRange(0, 5, 1)
   ->UseRealTime();
 // Single-threaded with weighted heuristics.
-BENCHMARK_CAPTURE(BM_Railroad, simple_single_threaded_weighted, Mode::SCALED, false)
-  ->Args({2, 2, 0});
+BENCHMARK_CAPTURE(BM_Railroad, scaled_single_thread, Mode::SCALED, false)->Args({2, 2, 0});
 // Weighted heuristics.
 BENCHMARK_CAPTURE(BM_Railroad, weighted, Mode::WEIGHTED)
   ->ArgsProduct({benchmark::CreateRange(1, 16, 2),

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -138,10 +138,9 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 }
 
 // Range all over all heuristics individually.
-BENCHMARK_CAPTURE(BM_Railroad, simple, Mode::SIMPLE)->DenseRange(0, 5, 1)->UseRealTime();
+BENCHMARK_CAPTURE(BM_Railroad, single_heuristic, Mode::SIMPLE)->DenseRange(0, 5, 1)->UseRealTime();
 // Single-threaded.
-BENCHMARK_CAPTURE(BM_Railroad, simple_single_threaded, Mode::SIMPLE, false)
-
+BENCHMARK_CAPTURE(BM_Railroad, signle_heuristic_single_threaded, Mode::SIMPLE, false)
   ->DenseRange(0, 5, 1)
   ->UseRealTime();
 // Single-threaded with weighted heuristics.

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -166,4 +166,8 @@ BENCHMARK_CAPTURE(BM_Railroad, weighted, Mode::WEIGHTED)
 BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
   ->ArgsProduct({benchmark::CreateRange(1, 8, 2), benchmark::CreateRange(1, 8, 2), {0}})
   ->UseRealTime();
-// BENCHMARK_CAPTURE(BM_Railroad, large, Mode::SCALED)->Args({2, 2, 2})->UseRealTime();
+BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
+  ->ArgsProduct({benchmark::CreateRange(1, 4, 2),
+                 benchmark::CreateRange(1, 4, 2),
+                 benchmark::CreateRange(1, 4, 2)})
+  ->UseRealTime();

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -111,9 +111,10 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 	auto               ata = mtl_ata_translation::translate(spec, action_aps);
 	const unsigned int K   = std::max(product.get_largest_constant(), spec.get_largest_constant());
 
-	std::size_t tree_size       = 0;
-	std::size_t controller_size = 0;
-	std::size_t plant_size      = 0;
+	std::size_t tree_size        = 0;
+	std::size_t pruned_tree_size = 0;
+	std::size_t controller_size  = 0;
+	std::size_t plant_size       = 0;
 
 	std::unique_ptr<search::Heuristic<long, Search::Node>> heuristic;
 
@@ -146,14 +147,23 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 		search.build_tree(multi_threaded);
 		search.label();
 		tree_size += search.get_size();
+		std::for_each(std::begin(search.get_nodes()),
+		              std::end(search.get_nodes()),
+		              [&pruned_tree_size](const auto &node) {
+			              if (node.second->label != search::NodeLabel::CANCELED
+			                  && node.second->label != search::NodeLabel::UNLABELED) {
+				              pruned_tree_size += 1;
+			              }
+		              });
 		plant_size += product.get_locations().size();
 		auto controller =
 		  controller_synthesis::create_controller(search.get_root(), camera_actions, robot_actions, K);
 		controller_size += controller.get_locations().size();
 	}
-	state.counters["tree_size"]       = tree_size;
-	state.counters["controller_size"] = controller_size;
-	state.counters["plant_size"]      = plant_size;
+	state.counters["tree_size"]        = tree_size;
+	state.counters["pruned_tree_size"] = pruned_tree_size;
+	state.counters["controller_size"]  = controller_size;
+	state.counters["plant_size"]       = plant_size;
 }
 
 BENCHMARK_CAPTURE(BM_Robot, single_heuristic, false)->DenseRange(0, 5, 1)->UseRealTime();

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -96,11 +96,15 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
                     {"c-camera"})});
 	const auto       product = automata::ta::get_product<std::string, std::string>({robot, camera});
 	const MTLFormula pick{AP{"pick"}};
+	const MTLFormula put{AP{"put"}};
 	const MTLFormula camera_on{AP{"switch-on"}};
 	const MTLFormula camera_off{AP{"switch-off"}};
-	const auto       spec =
-	  finally(pick, logic::TimeInterval(0, 1)).dual_until(!camera_on)
-	  || finally(camera_off && finally(pick, logic::TimeInterval(0, 1)).dual_until(!camera_on));
+	const auto spec = (!camera_on).until(pick) || finally(camera_off && (!camera_on).until(pick))
+	                  || finally(camera_on && finally(pick, logic::TimeInterval(0, 1)))
+	                  || (!camera_on).until(put) || finally(camera_off && (!camera_on).until(put))
+	                  || finally(camera_on && finally(put, logic::TimeInterval(0, 1)));
+	// finally(pick, logic::TimeInterval(0, 1)).dual_until(!camera_on)
+	//|| finally(camera_off && finally(pick, logic::TimeInterval(0, 1)).dual_until(!camera_on));
 	std::set<AP> action_aps;
 	for (const auto &a : robot_actions) {
 		action_aps.emplace(a);

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -23,6 +23,7 @@
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
 #include "search/create_controller.h"
+#include "search/heuristics.h"
 #include "search/search.h"
 
 #include <benchmark/benchmark.h>
@@ -34,7 +35,7 @@ using AP         = logic::AtomicProposition<std::string>;
 using automata::AtomicClockConstraintT;
 
 static void
-BM_Robot(benchmark::State &state)
+BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = true)
 {
 	spdlog::set_level(spdlog::level::err);
 	spdlog::set_pattern("%t %v");
@@ -114,17 +115,35 @@ BM_Robot(benchmark::State &state)
 	std::size_t controller_size = 0;
 	std::size_t plant_size      = 0;
 
+	std::unique_ptr<search::Heuristic<long, Search::Node>> heuristic;
+
 	for (auto _ : state) {
-		Search search(&product,
-		              &ata,
-		              camera_actions,
-		              robot_actions,
-		              K,
-		              true,
-		              true,
-		              generate_heuristic<Search::Node>(
-		                state.range(0), state.range(1), robot_actions, state.range(2)));
-		search.build_tree(true);
+		if (weighted) {
+			heuristic = generate_heuristic<Search::Node>(state.range(0),
+			                                             state.range(1),
+			                                             robot_actions,
+			                                             state.range(2));
+		} else {
+			if (state.range(0) == 0) {
+				heuristic = std::make_unique<search::BfsHeuristic<long, Search::Node>>();
+			} else if (state.range(0) == 1) {
+				heuristic = std::make_unique<search::DfsHeuristic<long, Search::Node>>();
+			} else if (state.range(0) == 2) {
+				heuristic = std::make_unique<search::NumCanonicalWordsHeuristic<long, Search::Node>>();
+			} else if (state.range(0) == 3) {
+				heuristic = std::make_unique<
+				  search::PreferEnvironmentActionHeuristic<long, Search::Node, std::string>>(robot_actions);
+			} else if (state.range(0) == 4) {
+				heuristic = std::make_unique<search::TimeHeuristic<long, Search::Node>>();
+			} else if (state.range(0) == 5) {
+				heuristic = std::make_unique<search::RandomHeuristic<long, Search::Node>>(time(NULL));
+			} else {
+				throw std::invalid_argument("Unexpected argument");
+			}
+		}
+		Search search(
+		  &product, &ata, camera_actions, robot_actions, K, true, true, std::move(heuristic));
+		search.build_tree(multi_threaded);
 		tree_size += search.get_size();
 		plant_size += product.get_locations().size();
 		auto controller =
@@ -136,7 +155,11 @@ BM_Robot(benchmark::State &state)
 	state.counters["plant_size"]      = plant_size;
 }
 
-BENCHMARK(BM_Robot)
+BENCHMARK_CAPTURE(BM_Robot, single_heuristic, false)->DenseRange(0, 5, 1)->UseRealTime();
+BENCHMARK_CAPTURE(BM_Robot, single_heuristic_single_thread, false, false)
+  ->DenseRange(0, 5, 1)
+  ->UseRealTime();
+BENCHMARK_CAPTURE(BM_Robot, weighted, true)
   ->ArgsProduct({benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateDenseRange(0, 2, 1)})

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -103,8 +103,6 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 	                  || finally(camera_on && finally(pick, logic::TimeInterval(0, 1)))
 	                  || (!camera_on).until(put) || finally(camera_off && (!camera_on).until(put))
 	                  || finally(camera_on && finally(put, logic::TimeInterval(0, 1)));
-	// finally(pick, logic::TimeInterval(0, 1)).dual_until(!camera_on)
-	//|| finally(camera_off && finally(pick, logic::TimeInterval(0, 1)).dual_until(!camera_on));
 	std::set<AP> action_aps;
 	for (const auto &a : robot_actions) {
 		action_aps.emplace(a);

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -144,6 +144,7 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 		Search search(
 		  &product, &ata, camera_actions, robot_actions, K, true, true, std::move(heuristic));
 		search.build_tree(multi_threaded);
+		search.label();
 		tree_size += search.get_size();
 		plant_size += product.get_locations().size();
 		auto controller =


### PR DESCRIPTION
This adds the conveyor belt benchmark and adapts or extends and unifies the other benchmarks.

Commit c3f38841f24c48f091b9fddfa45eeda6c2c91394 also contains a fix for a bug if we have a loop in the search graph, which sometimes results in no labeling, as we did not properly detect monotonic domination.

This is the set of benchmarks as used for SEFM.