### PR TITLE
automata: rename target from ta to automata

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Protobuf REQUIRED)
 add_library(app SHARED app.cpp)
 target_link_libraries(
   app
-  PUBLIC ta
+  PUBLIC automata
          ta_proto
          mtl_ata_translation
          search

--- a/src/automata/CMakeLists.txt
+++ b/src/automata/CMakeLists.txt
@@ -1,13 +1,13 @@
-add_library(ta SHARED ta.cpp automata.cpp ata.cpp ta_regions.cpp)
-target_link_libraries(ta PUBLIC range-v3::range-v3 utilities fmt::fmt NamedType)
+add_library(automata SHARED ta.cpp automata.cpp ata.cpp ta_regions.cpp)
+target_link_libraries(automata PUBLIC range-v3::range-v3 utilities fmt::fmt NamedType)
 target_include_directories(
-  ta
+  automata
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>
          ${Boost_INCLUDE_DIR})
 
 install(
-  TARGETS ta
+  TARGETS automata
   EXPORT TacosTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -21,7 +21,7 @@ if(Protobuf_FOUND)
   add_library(ta_proto SHARED ta_proto.cpp ${PROTO_SRCS} ${PROTO_HDRS})
   target_link_libraries(
     ta_proto
-    PUBLIC ta protobuf::libprotobuf
+    PUBLIC automata protobuf::libprotobuf
     PRIVATE range-v3::range-v3)
   target_include_directories(
     ta_proto

--- a/src/mtl_ata_translation/CMakeLists.txt
+++ b/src/mtl_ata_translation/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(mtl_ata_translation SHARED translator.cpp)
-target_link_libraries(mtl_ata_translation PUBLIC ta mtl fmt::fmt)
+target_link_libraries(mtl_ata_translation PUBLIC automata mtl fmt::fmt)
 target_include_directories(
   mtl_ata_translation
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(search SHARED search_tree.cpp)
-target_link_libraries(search PUBLIC ta mtl utilities spdlog::spdlog fmt::fmt
+target_link_libraries(search PUBLIC automata mtl utilities spdlog::spdlog fmt::fmt
                                     mtl_ata_translation)
 target_include_directories(
   search PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(utilities INTERFACE)
-target_link_libraries(utilities INTERFACE ta tinyxml2 pthread)
+target_link_libraries(utilities INTERFACE automata tinyxml2 pthread)
 target_include_directories(
   utilities INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,20 +3,20 @@ if (COVERAGE)
 endif()
 
 add_library(railroad SHARED railroad.cpp)
-target_link_libraries(railroad PUBLIC ta search mtl visualization)
+target_link_libraries(railroad PUBLIC automata search mtl visualization)
 
 add_library(railroad_location SHARED railroad_location.cpp)
-target_link_libraries(railroad_location PUBLIC ta search mtl visualization)
+target_link_libraries(railroad_location PUBLIC automata search mtl visualization)
 
 add_library(fischer SHARED fischer.cpp)
-target_link_libraries(fischer PUBLIC ta search)
+target_link_libraries(fischer PUBLIC automata search)
 
 add_executable(test_clock test_clock.cpp)
-target_link_libraries(test_clock PRIVATE ta Catch2::Catch2WithMain)
+target_link_libraries(test_clock PRIVATE automata Catch2::Catch2WithMain)
 catch_discover_tests(test_clock)
 
 add_executable(testta test_ta.cpp test_ta_region.cpp test_ta_print.cpp test_ta_product.cpp)
-target_link_libraries(testta PRIVATE ta PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(testta PRIVATE automata PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(testta)
 
 add_executable(testinterval test_interval.cpp)
@@ -32,7 +32,7 @@ target_link_libraries(testmtlformulae PRIVATE mtl PRIVATE Catch2::Catch2WithMain
 catch_discover_tests(testmtlformulae)
 
 add_executable(testata test_ata_formula.cpp test_ata.cpp test_print_ata.cpp test_print_ata_formula.cpp)
-target_link_libraries(testata PRIVATE ta PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(testata PRIVATE automata PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(testata)
 
 add_executable(test_mtl_ata_translation test_mtl_ata_translation.cpp)
@@ -92,7 +92,7 @@ find_package(Protobuf QUIET)
 if (Protobuf_FOUND)
 
   add_executable(test_ta_proto test_ta_proto.cpp)
-  target_link_libraries(test_ta_proto PRIVATE ta ta_proto Catch2::Catch2WithMain)
+  target_link_libraries(test_ta_proto PRIVATE automata ta_proto Catch2::Catch2WithMain)
   catch_discover_tests(test_ta_proto)
 
   add_executable(test_mtl_proto test_mtl_proto.cpp)


### PR DESCRIPTION
The library was already named libautomata, adapt the target accordingly.