### PR TITLE
Fix ostream output for conjunctions/disjunctions with less or more than two operands

### DIFF
--- a/examples/railroad/spec.pbtxt
+++ b/examples/railroad/spec.pbtxt
@@ -1,28 +1,24 @@
 disjunction {
   disjuncts {
-    disjunction {
-      disjuncts {
-        dual_until {
-          front {
-            atomic { symbol: "enter" }
-          }
-          back {
-            negation {
-             formula { atomic { symbol: "finish_close" } }
-            }
-          }
+    dual_until {
+      front {
+        atomic { symbol: "enter" }
+      }
+      back {
+        negation {
+         formula { atomic { symbol: "finish_close" } }
         }
       }
-      disjuncts {
-        dual_until {
-          front {
-            atomic { symbol: "start_open" }
-          }
-          back {
-            negation {
-             formula { atomic { symbol: "leave" } }
-            }
-          }
+    }
+  }
+  disjuncts {
+    dual_until {
+      front {
+        atomic { symbol: "start_open" }
+      }
+      back {
+        negation {
+         formula { atomic { symbol: "leave" } }
         }
       }
     }

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -63,12 +63,50 @@ operator<<(std::ostream &out, const logic::MTLFormula<APType> &f)
 	case LOP::TRUE: out << u8"⊤"; break;
 	case LOP::FALSE: out << u8"⊥"; break;
 	case LOP::AP: out << f.get_atomicProposition(); break;
-	case LOP::LAND:
-		out << "(" << f.get_operands().front() << " ∧ " << f.get_operands().back() << ")";
+	case LOP::LAND: {
+		if (f.get_operands().empty()) {
+			out << u8"⊤";
+			break;
+		}
+		if (f.get_operands().size() == 1) {
+			out << f.get_operands().front();
+			break;
+		}
+		out << "(";
+		bool first = true;
+		for (const auto &op : f.get_operands()) {
+			if (first) {
+				first = false;
+			} else {
+				out << " ∧ ";
+			}
+			out << op;
+		}
+		out << ")";
 		break;
-	case LOP::LOR:
-		out << "(" << f.get_operands().front() << " ∨ " << f.get_operands().back() << ")";
+	}
+	case LOP::LOR: {
+		if (f.get_operands().empty()) {
+			out << u8"⊥";
+			break;
+		}
+		if (f.get_operands().size() == 1) {
+			out << f.get_operands().front();
+			break;
+		}
+		out << "(";
+		bool first = true;
+		for (const auto &op : f.get_operands()) {
+			if (first) {
+				first = false;
+			} else {
+				out << " ∨ ";
+			}
+			out << op;
+		}
+		out << ")";
 		break;
+	}
 	case LOP::LNEG: out << "!(" << f.get_operands().front() << ")"; break;
 	case LOP::LUNTIL: print_until(out, f, "U"); break;
 	case LOP::LDUNTIL: print_until(out, f, "~U"); break;

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -86,26 +86,52 @@ TEST_CASE("MTL construction from a vector of operands", "[libmtl]")
 	logic::AtomicProposition<std::string> a{"a"};
 	logic::AtomicProposition<std::string> b{"b"};
 	logic::AtomicProposition<std::string> c{"c"};
-	auto conjunction = logic::MTLFormula<std::string>::create_conjunction({a, b, c});
+	// Conjunction
+	const auto conjunction = logic::MTLFormula<std::string>::create_conjunction({a, b, c});
+	CAPTURE(conjunction);
 	CHECK(logic::MTLWord<std::string>{{{a, b, c}, 0}}.satisfies(conjunction));
 	CHECK(!logic::MTLWord<std::string>{{{a, b}, 0}}.satisfies(conjunction));
 	CHECK(!logic::MTLWord<std::string>{{{a, c}, 0}}.satisfies(conjunction));
+	CHECK(!logic::MTLWord<std::string>{{{b, c}, 0}}.satisfies(conjunction));
+	CHECK(!logic::MTLWord<std::string>{{{a}, 0}}.satisfies(conjunction));
+	CHECK(!logic::MTLWord<std::string>{{{b}, 0}}.satisfies(conjunction));
+	CHECK(!logic::MTLWord<std::string>{{{c}, 0}}.satisfies(conjunction));
 	CHECK(!logic::MTLWord<std::string>{{{}, 0}}.satisfies(conjunction));
 	// Negate the conjunction.
 	CHECK(!logic::MTLWord<std::string>{{{a, b, c}, 0}}.satisfies(!conjunction));
 	CHECK(logic::MTLWord<std::string>{{{a, b}, 0}}.satisfies(!conjunction));
 	CHECK(logic::MTLWord<std::string>{{{a, c}, 0}}.satisfies(!conjunction));
+	CHECK(logic::MTLWord<std::string>{{{b, c}, 0}}.satisfies(!conjunction));
+	CHECK(logic::MTLWord<std::string>{{{a}, 0}}.satisfies(!conjunction));
+	CHECK(logic::MTLWord<std::string>{{{b}, 0}}.satisfies(!conjunction));
+	CHECK(logic::MTLWord<std::string>{{{c}, 0}}.satisfies(!conjunction));
 	CHECK(logic::MTLWord<std::string>{{{}, 0}}.satisfies(!conjunction));
-	auto disjunction = logic::MTLFormula<std::string>::create_disjunction({a, b, c});
+	// Empty conjunction
+	CHECK(logic::MTLWord<std::string>{{{a, b, c}, 0}}.satisfies(
+	  logic::MTLFormula<std::string>::create_conjunction({})));
+	// Disjunction
+	const auto disjunction = logic::MTLFormula<std::string>::create_disjunction({a, b, c});
+	CAPTURE(disjunction);
 	CHECK(logic::MTLWord<std::string>{{{a, b, c}, 0}}.satisfies(disjunction));
 	CHECK(logic::MTLWord<std::string>{{{a, b}, 0}}.satisfies(disjunction));
 	CHECK(logic::MTLWord<std::string>{{{a, c}, 0}}.satisfies(disjunction));
+	CHECK(logic::MTLWord<std::string>{{{b, c}, 0}}.satisfies(disjunction));
+	CHECK(logic::MTLWord<std::string>{{{a}, 0}}.satisfies(disjunction));
+	CHECK(logic::MTLWord<std::string>{{{b}, 0}}.satisfies(disjunction));
+	CHECK(logic::MTLWord<std::string>{{{c}, 0}}.satisfies(disjunction));
 	CHECK(!logic::MTLWord<std::string>{{{}, 0}}.satisfies(disjunction));
 	// Negate the disjunction.
 	CHECK(!logic::MTLWord<std::string>{{{a, b, c}, 0}}.satisfies(!disjunction));
 	CHECK(!logic::MTLWord<std::string>{{{a, b}, 0}}.satisfies(!disjunction));
 	CHECK(!logic::MTLWord<std::string>{{{a, c}, 0}}.satisfies(!disjunction));
+	CHECK(!logic::MTLWord<std::string>{{{b, c}, 0}}.satisfies(!disjunction));
+	CHECK(!logic::MTLWord<std::string>{{{a}, 0}}.satisfies(!disjunction));
+	CHECK(!logic::MTLWord<std::string>{{{b}, 0}}.satisfies(!disjunction));
+	CHECK(!logic::MTLWord<std::string>{{{c}, 0}}.satisfies(!disjunction));
 	CHECK(logic::MTLWord<std::string>{{{}, 0}}.satisfies(!disjunction));
+	// Empty disjunction
+	CHECK(!logic::MTLWord<std::string>{{{a, b, c}, 0}}.satisfies(
+	  logic::MTLFormula<std::string>::create_disjunction({})));
 }
 
 TEST_CASE("Dual until", "[libmtl]")

--- a/test/test_mtl_proto.cpp
+++ b/test/test_mtl_proto.cpp
@@ -93,6 +93,17 @@ TEST_CASE("Import MTL formulas from a proto", "[libmtl][proto]")
 		CHECK(parse_proto(proto_formula) == (a || b));
 	}
 
+	SECTION("Disjunction with three sub-formulas")
+	{
+		REQUIRE(TextFormat::ParseFromString(R"pb(disjunction {
+                                               disjuncts { atomic { symbol: "a" } }
+                                               disjuncts { atomic { symbol: "b" } }
+                                               disjuncts { atomic { symbol: "c" } }
+                                             })pb",
+		                                    &proto_formula));
+		CHECK(parse_proto(proto_formula) == MTLFormula::create_disjunction({a, b, c}));
+	}
+
 	SECTION("Negation")
 	{
 		REQUIRE(TextFormat::ParseFromString(R"pb(negation { formula { atomic { symbol: "a" } } })pb",

--- a/test/test_mtl_proto.cpp
+++ b/test/test_mtl_proto.cpp
@@ -72,6 +72,17 @@ TEST_CASE("Import MTL formulas from a proto", "[libmtl][proto]")
 		CHECK(parse_proto(proto_formula) == (a && b));
 	}
 
+	SECTION("Conjunction with three sub-formulas")
+	{
+		REQUIRE(TextFormat::ParseFromString(R"pb(conjunction {
+                                               conjuncts { atomic { symbol: "a" } }
+                                               conjuncts { atomic { symbol: "b" } }
+                                               conjuncts { atomic { symbol: "c" } }
+                                             })pb",
+		                                    &proto_formula));
+		CHECK(parse_proto(proto_formula) == MTLFormula::create_conjunction({a, b, c}));
+	}
+
 	SECTION("Disjunction")
 	{
 		REQUIRE(TextFormat::ParseFromString(R"pb(disjunction {

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -32,43 +32,44 @@ TEST_CASE("Print MTL formulas", "[print][mtl]")
 {
 	using Formula = logic::MTLFormula<std::string>;
 	using AP      = logic::AtomicProposition<std::string>;
+	std::stringstream s;
+	SECTION("atom")
 	{
-		std::stringstream s;
 		s << Formula{AP{"a"}};
 		CHECK(s.str() == "a");
 	}
+	SECTION("long atom")
 	{
-		std::stringstream s;
 		s << Formula(AP("a long atomic proposition"));
 		CHECK(s.str() == "a long atomic proposition");
 	}
+	SECTION("conjunction")
 	{
-		std::stringstream s;
 		s << (Formula{AP{"a"}} && Formula{AP{"b"}});
 		CHECK(s.str() == "(a ∧ b)");
 	}
+	SECTION("disjunction")
 	{
-		std::stringstream s;
 		s << (Formula{AP{"a"}} || Formula{AP{"b"}});
 		CHECK(s.str() == "(a ∨ b)");
 	}
+	SECTION("until")
 	{
-		std::stringstream s;
 		s << (Formula(AP{"a"}).until(Formula{AP{"b"}}));
 		CHECK(s.str() == "(a U b)");
 	}
+	SECTION("until with time bounds")
 	{
-		std::stringstream s;
 		s << (Formula(AP{"a"}).until(Formula{AP{"b"}}, TimeInterval(1, 2)));
 		CHECK(s.str() == "(a U(1, 2) b)");
 	}
+	SECTION("dual until")
 	{
-		std::stringstream s;
 		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}}));
 		CHECK(s.str() == "(a ~U b)");
 	}
+	SECTION("dual until with time bounds")
 	{
-		std::stringstream s;
 		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}}, TimeInterval(1, 2)));
 		CHECK(s.str() == "(a ~U(1, 2) b)");
 	}

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -48,10 +48,40 @@ TEST_CASE("Print MTL formulas", "[print][mtl]")
 		s << (Formula{AP{"a"}} && Formula{AP{"b"}});
 		CHECK(s.str() == "(a ∧ b)");
 	}
+	SECTION("empty conjunction")
+	{
+		s << Formula::create_conjunction({});
+		CHECK(s.str() == u8"⊤");
+	}
+	SECTION("conjunction with a single conjunct")
+	{
+		s << Formula::create_conjunction({AP{"a"}});
+		CHECK(s.str() == "a");
+	}
+	SECTION("conjunction with three conjuncts")
+	{
+		s << Formula::create_conjunction({AP{"a"}, AP{"b"}, AP{"c"}});
+		CHECK(s.str() == "(a ∧ b ∧ c)");
+	}
 	SECTION("disjunction")
 	{
 		s << (Formula{AP{"a"}} || Formula{AP{"b"}});
 		CHECK(s.str() == "(a ∨ b)");
+	}
+	SECTION("empty disjunction")
+	{
+		s << Formula::create_disjunction({});
+		CHECK(s.str() == u8"⊥");
+	}
+	SECTION("disjunction with a single conjunct")
+	{
+		s << Formula::create_disjunction({AP{"a"}});
+		CHECK(s.str() == "a");
+	}
+	SECTION("disjunction with three conjuncts")
+	{
+		s << Formula::create_disjunction({AP{"a"}, AP{"b"}, AP{"c"}});
+		CHECK(s.str() == "(a ∨ b ∨ c)");
 	}
 	SECTION("until")
 	{


### PR DESCRIPTION
I initially thought that this is a bug in the protobuf import, but it turns out we just did not print conjunctions and disjunctions with less or more than two operands correctly. Thus,
* fix the output of conjunctions and disjunctions
* extend the print test cases to make sure it is working correctly
* also extend the satisfaction checks to cover all cases, just to make sure the formula works as expected
* extend the protobuf import test to also have three conjuncts and disjuncts