### PR TITLE
Adapt to Catch2 renaming: Contains -> ContainsSubstring

### DIFF
--- a/test/test_graphviz.cpp
+++ b/test/test_graphviz.cpp
@@ -25,7 +25,7 @@
 
 namespace {
 
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 using tacos::utilities::graphviz::Graph;
 
 TEST_CASE("Create a graphviz graph", "[utilities][graphviz]")
@@ -41,17 +41,17 @@ TEST_CASE("Create a graphviz graph", "[utilities][graphviz]")
 	g.add_edge(n2, n3, "foo bar");
 	g.add_edge(n2, n4, "foo baz");
 	const auto dot = g.to_dot();
-	CHECK_THAT(dot, Contains("\"node 1\""));
-	CHECK_THAT(dot, Contains("\"node 2\""));
-	CHECK_THAT(dot, Contains("\"node 3\""));
-	CHECK_THAT(dot, Contains("\"node 4\""));
-	CHECK_THAT(dot, Contains("1 -> 2"));
-	CHECK_THAT(dot, Contains("2 -> 3"));
-	CHECK_THAT(dot, Contains("2 -> 4"));
-	CHECK_THAT(dot, Contains("label=\"foo bar\""));
-	CHECK_THAT(dot, Contains("label=\"foo baz\""));
-	CHECK_THAT(dot, Contains("color=red"));
-	CHECK_THAT(dot, Contains("color=green"));
+	CHECK_THAT(dot, ContainsSubstring("\"node 1\""));
+	CHECK_THAT(dot, ContainsSubstring("\"node 2\""));
+	CHECK_THAT(dot, ContainsSubstring("\"node 3\""));
+	CHECK_THAT(dot, ContainsSubstring("\"node 4\""));
+	CHECK_THAT(dot, ContainsSubstring("1 -> 2"));
+	CHECK_THAT(dot, ContainsSubstring("2 -> 3"));
+	CHECK_THAT(dot, ContainsSubstring("2 -> 4"));
+	CHECK_THAT(dot, ContainsSubstring("label=\"foo bar\""));
+	CHECK_THAT(dot, ContainsSubstring("label=\"foo baz\""));
+	CHECK_THAT(dot, ContainsSubstring("color=red"));
+	CHECK_THAT(dot, ContainsSubstring("color=green"));
 	g.render_to_file("graphviz.png");
 	CHECK_THROWS(g.render_to_file("nosuffix"));
 	CHECK_NOTHROW(tacos::utilities::graphviz::Node{}.set_property("color", "red"));
@@ -72,10 +72,10 @@ TEST_CASE("Create a graphviz graph with custom identifiers", "[utilities][graphv
 	g.get_node("n1")->set_property("color", "green");
 	const auto dot = g.to_dot();
 	// We used the same identifier for node 2, so node 1 should not occur.
-	CHECK_THAT(dot, !Contains("node 1"));
-	CHECK_THAT(dot, Contains("node 2"));
-	CHECK_THAT(dot, Contains("color=green"));
-	CHECK_THAT(dot, !Contains("color=red"));
+	CHECK_THAT(dot, !ContainsSubstring("node 1"));
+	CHECK_THAT(dot, ContainsSubstring("node 2"));
+	CHECK_THAT(dot, ContainsSubstring("color=green"));
+	CHECK_THAT(dot, !ContainsSubstring("color=red"));
 }
 
 } // namespace

--- a/test/test_ta_visualization.cpp
+++ b/test/test_ta_visualization.cpp
@@ -33,7 +33,7 @@ using Location   = automata::ta::Location<std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
 using tacos::visualization::ta_to_graphviz;
 
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 TEST_CASE("Visualize a TA", "[visualization]")
 {
 	TA ta{{Location{"l0"}, Location{"l1"}},
@@ -50,20 +50,20 @@ TEST_CASE("Visualize a TA", "[visualization]")
 	{
 		auto g   = ta_to_graphviz(ta);
 		auto dot = g.to_dot();
-		CHECK_THAT(dot, Contains("label=l0"));
-		CHECK_THAT(dot, Contains("label=l1"));
-		CHECK_THAT(dot, Contains("c < 2"));
-		CHECK_THAT(dot, Contains("{c}"));
+		CHECK_THAT(dot, ContainsSubstring("label=l0"));
+		CHECK_THAT(dot, ContainsSubstring("label=l1"));
+		CHECK_THAT(dot, ContainsSubstring("c < 2"));
+		CHECK_THAT(dot, ContainsSubstring("{c}"));
 	}
 	SECTION("Compact graph")
 	{
 		auto g   = ta_to_graphviz(ta, false);
 		auto dot = g.to_dot();
-		CHECK_THAT(dot, Contains("label=l0"));
-		CHECK_THAT(dot, Contains("label=l1"));
-		CHECK_THAT(dot, Contains("c < 2"));
-		CHECK_THAT(dot, Contains("{c}"));
-		CHECK_THAT(dot, Contains("shape=point"));
+		CHECK_THAT(dot, ContainsSubstring("label=l0"));
+		CHECK_THAT(dot, ContainsSubstring("label=l1"));
+		CHECK_THAT(dot, ContainsSubstring("c < 2"));
+		CHECK_THAT(dot, ContainsSubstring("{c}"));
+		CHECK_THAT(dot, ContainsSubstring("shape=point"));
 	}
 }
 

--- a/test/test_tree_visualization.cpp
+++ b/test/test_tree_visualization.cpp
@@ -42,7 +42,7 @@ using TARegionState   = search::TARegionState<std::string>;
 using search::LabelReason;
 using search::NodeLabel;
 
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 
 auto
 create_test_graph()
@@ -102,45 +102,47 @@ TEST_CASE("Search tree visualization", "[search][visualization]")
 	const auto dot = graph.to_dot();
 
 	// All nodes should have shape 'record'.
-	CHECK_THAT(dot, Contains("shape=record"));
+	CHECK_THAT(dot, ContainsSubstring("shape=record"));
 
 	// Check that all nodes have the expected labels.
 	CHECK_THAT(dot,
-	           Contains(
+	           ContainsSubstring(
 	             R"dot(label="{good controller action first}|{ { (l0, x, 0), (l0, y, 0) } }")dot"));
-	CHECK_THAT(dot, Contains(R"dot(label="{dead node}|{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 	CHECK_THAT(dot,
-	           Contains(R"dot(label="{no bad env action}|{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
+	           ContainsSubstring(R"dot(label="{dead node}|{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
+	CHECK_THAT(dot,
+	           ContainsSubstring(
+	             R"dot(label="{no bad env action}|{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
 	CHECK_THAT(
 	  dot,
-	  Contains(
+	  ContainsSubstring(
 	    R"dot(label="{bad env action first}|{ { (l0, x, 1) }|{ (l0, y, 2) } }|{ { (l0, x, 1), ((a U b), 1) }|{ (l0, y, 2) } }")dot"));
 
 	// Check that both colors occur, we assume they are the right nodes.
-	CHECK_THAT(dot, Contains("color=green"));
-	CHECK_THAT(dot, Contains("color=red"));
+	CHECK_THAT(dot, ContainsSubstring("color=green"));
+	CHECK_THAT(dot, ContainsSubstring("color=red"));
 
 	// Check that all four edges occur.
 	CHECK_THAT(dot,
-	           Contains(
+	           ContainsSubstring(
 	             R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 	CHECK_THAT(dot,
-	           Contains(
+	           ContainsSubstring(
 	             R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
 	CHECK_THAT(
 	  dot,
-	  Contains(
+	  ContainsSubstring(
 	    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }|{ { (l0, x, 1), ((a U b), 1) }|{ (l0, y, 2) } }")dot"));
 	CHECK_THAT(
 	  dot,
-	  Contains(
+	  ContainsSubstring(
 	    R"dot("{ { (l0, x, 0) }|{ (l0, y, 1) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 2) } }")dot"));
 
 	// Check that all three actions occur.
-	CHECK_THAT(dot, Contains("(1, a)"));
-	CHECK_THAT(dot, Contains("(2, b)"));
-	CHECK_THAT(dot, Contains("(3, c)"));
-	CHECK_THAT(dot, Contains("(1, d)"));
+	CHECK_THAT(dot, ContainsSubstring("(1, a)"));
+	CHECK_THAT(dot, ContainsSubstring("(2, b)"));
+	CHECK_THAT(dot, ContainsSubstring("(3, c)"));
+	CHECK_THAT(dot, ContainsSubstring("(1, d)"));
 }
 
 TEST_CASE("Interactive visualization", "[visualization]")
@@ -156,7 +158,7 @@ TEST_CASE("Interactive visualization", "[visualization]")
 		visualization::search_tree_to_graphviz_interactive(root.get(), tmp_file, input);
 		std::string dot = read_file(tmp_file);
 		CAPTURE(dot);
-		CHECK_THAT(dot, Contains("{ { (l0, x, 0), (l0, y, 0) } }"));
+		CHECK_THAT(dot, ContainsSubstring("{ { (l0, x, 0), (l0, y, 0) } }"));
 	}
 	SECTION("First child")
 	{
@@ -166,7 +168,8 @@ TEST_CASE("Interactive visualization", "[visualization]")
 		CAPTURE(dot);
 		CHECK_THAT(
 		  dot,
-		  Contains(R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
+		  ContainsSubstring(
+		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 	}
 	SECTION("Undo")
 	{
@@ -176,7 +179,7 @@ TEST_CASE("Interactive visualization", "[visualization]")
 		CAPTURE(dot);
 		CHECK_THAT(
 		  dot,
-		  !Contains(
+		  !ContainsSubstring(
 		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 	}
 	SECTION("All of root's children")
@@ -187,19 +190,21 @@ TEST_CASE("Interactive visualization", "[visualization]")
 		CAPTURE(dot);
 		CHECK_THAT(
 		  dot,
-		  Contains(R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
+		  ContainsSubstring(
+		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  Contains(R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
+		  ContainsSubstring(
+		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  Contains(
+		  ContainsSubstring(
 		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }|{ { (l0, x, 1), ((a U b), 1) }|{ (l0, y, 2) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  !Contains(
+		  !ContainsSubstring(
 		    R"dot("{ { (l0, x, 0) }|{ (l0, y, 1) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 2) } }")dot"));
-		CHECK_THAT(dot, !Contains("(1, d)"));
+		CHECK_THAT(dot, !ContainsSubstring("(1, d)"));
 	}
 	SECTION("Child of the first child with separate selection and navigation")
 	{
@@ -209,18 +214,19 @@ TEST_CASE("Interactive visualization", "[visualization]")
 		CAPTURE(dot);
 		CHECK_THAT(
 		  dot,
-		  Contains(R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
+		  ContainsSubstring(
+		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  !Contains(
+		  !ContainsSubstring(
 		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  !Contains(
+		  !ContainsSubstring(
 		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }|{ { (l0, x, 1), ((a U b), 1) }|{ (l0, y, 2) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  Contains(
+		  ContainsSubstring(
 		    R"dot("{ { (l0, x, 0) }|{ (l0, y, 1) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 2) } }")dot"));
 	}
 	SECTION("Child of the first child with simultaneous selection and navigation")
@@ -231,18 +237,19 @@ TEST_CASE("Interactive visualization", "[visualization]")
 		CAPTURE(dot);
 		CHECK_THAT(
 		  dot,
-		  Contains(R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
+		  ContainsSubstring(
+		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 1) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  !Contains(
+		  !ContainsSubstring(
 		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  !Contains(
+		  !ContainsSubstring(
 		    R"dot("{ { (l0, x, 0), (l0, y, 0) } }" -> "{ { (l0, x, 1) }|{ (l0, y, 2) } }|{ { (l0, x, 1), ((a U b), 1) }|{ (l0, y, 2) } }")dot"));
 		CHECK_THAT(
 		  dot,
-		  Contains(
+		  ContainsSubstring(
 		    R"dot("{ { (l0, x, 0) }|{ (l0, y, 1) } }" -> "{ { (l0, x, 0) }|{ (l0, y, 2) } }")dot"));
 	}
 	remove(tmp_file);

--- a/test/test_xml_writer.cpp
+++ b/test/test_xml_writer.cpp
@@ -20,8 +20,11 @@
 #include "io/XmlWriter.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 namespace {
+
+using Catch::Matchers::ContainsSubstring;
 
 using namespace tacos;
 
@@ -53,14 +56,14 @@ TEST_CASE("Write constraint to xml", "[io]")
 	tinyxml2::XMLPrinter prnt{};
 	doc.SaveFile("test.xml");
 	doc.Print(&prnt);
-	std::string res = std::string(prnt.CStr());
-	CHECK(res.find("<root>") != std::string::npos);
-	CHECK(res.find("</root>") != std::string::npos);
-	CHECK(res.find("<label kind=\"guard\">x &lt; 1</label>") != std::string::npos);
-	CHECK(res.find("<label kind=\"guard\">x &lt;= 2</label>") != std::string::npos);
-	CHECK(res.find("<label kind=\"guard\">x == 3</label>") != std::string::npos);
-	CHECK(res.find("<label kind=\"guard\">x &gt;= 4</label>") != std::string::npos);
-	CHECK(res.find("<label kind=\"guard\">x &gt; 5</label>") != std::string::npos);
+	const std::string res{prnt.CStr()};
+	CHECK_THAT(res, ContainsSubstring("<root>"));
+	CHECK_THAT(res, ContainsSubstring("</root>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"guard\">x &lt; 1</label>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"guard\">x &lt;= 2</label>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"guard\">x == 3</label>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"guard\">x &gt;= 4</label>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"guard\">x &gt; 5</label>"));
 }
 
 TEST_CASE("Write transition to xml", "[io]")
@@ -76,14 +79,14 @@ TEST_CASE("Write transition to xml", "[io]")
 	tinyxml2::XMLPrinter prnt{};
 	doc.SaveFile("test.xml");
 	doc.Print(&prnt);
-	std::string res = std::string(prnt.CStr());
-	CHECK(res.find("<root>") != std::string::npos);
-	CHECK(res.find("</root>") != std::string::npos);
-	CHECK(res.find("<transition>") != std::string::npos);
-	CHECK(res.find("</transition>") != std::string::npos);
-	CHECK(res.find("<source ref=\"l0\"/>") != std::string::npos);
-	CHECK(res.find("<target ref=\"l1\"/>") != std::string::npos);
-	CHECK(res.find("<label kind=\"synchronization\">a!</label>") != std::string::npos);
+	const std::string res{prnt.CStr()};
+	CHECK_THAT(res, ContainsSubstring("<root>"));
+	CHECK_THAT(res, ContainsSubstring("</root>"));
+	CHECK_THAT(res, ContainsSubstring("<transition>"));
+	CHECK_THAT(res, ContainsSubstring("</transition>"));
+	CHECK_THAT(res, ContainsSubstring("<source ref=\"l0\"/>"));
+	CHECK_THAT(res, ContainsSubstring("<target ref=\"l1\"/>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"synchronization\">a!</label>"));
 }
 
 TEST_CASE("Write ta to xml", "[io]")
@@ -111,20 +114,20 @@ TEST_CASE("Write ta to xml", "[io]")
 	tinyxml2::XMLPrinter prnt{};
 	doc.SaveFile("test.xml");
 	doc.Print(&prnt);
-	std::string res = std::string(prnt.CStr());
-	CHECK(res.find("<nta>") != std::string::npos);
-	CHECK(res.find("<name>simple_automaton</name>") != std::string::npos);
-	CHECK(res.find("</nta>") != std::string::npos);
-	CHECK(res.find("<transition>") != std::string::npos);
-	CHECK(res.find("</transition>") != std::string::npos);
-	CHECK(res.find("<location id=\"s0\">") != std::string::npos);
-	CHECK(res.find("<name>s0</name>") != std::string::npos);
-	CHECK(res.find("</location>") != std::string::npos);
-	CHECK(res.find("<source ref=\"s0\"/>") != std::string::npos);
-	CHECK(res.find("<target ref=\"s0\"/>") != std::string::npos);
-	CHECK(res.find("<label kind=\"guard\">x &lt; 2</label>") != std::string::npos);
-	CHECK(res.find("<label kind=\"assignment\">x := 0</label>") != std::string::npos);
-	CHECK(res.find("<label kind=\"synchronization\">a!</label>") != std::string::npos);
+	const std::string res{prnt.CStr()};
+	CHECK_THAT(res, ContainsSubstring("<nta>"));
+	CHECK_THAT(res, ContainsSubstring("<name>simple_automaton</name>"));
+	CHECK_THAT(res, ContainsSubstring("</nta>"));
+	CHECK_THAT(res, ContainsSubstring("<transition>"));
+	CHECK_THAT(res, ContainsSubstring("</transition>"));
+	CHECK_THAT(res, ContainsSubstring("<location id=\"s0\">"));
+	CHECK_THAT(res, ContainsSubstring("<name>s0</name>"));
+	CHECK_THAT(res, ContainsSubstring("</location>"));
+	CHECK_THAT(res, ContainsSubstring("<source ref=\"s0\"/>"));
+	CHECK_THAT(res, ContainsSubstring("<target ref=\"s0\"/>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"guard\">x &lt; 2</label>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"assignment\">x := 0</label>"));
+	CHECK_THAT(res, ContainsSubstring("<label kind=\"synchronization\">a!</label>"));
 }
 
 TEST_CASE("Write composition to xml", "[io]")

--- a/test/test_xml_writer.cpp
+++ b/test/test_xml_writer.cpp
@@ -20,7 +20,6 @@
 #include "io/XmlWriter.h"
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_string.hpp>
 
 namespace {
 
@@ -28,8 +27,6 @@ using namespace tacos;
 
 using Location   = automata::ta::Location<std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
-
-using Catch::Matchers::Contains;
 
 TEST_CASE("Write constraint to xml", "[io]")
 {


### PR DESCRIPTION
The Contains matcher for strings was renamed to ContainsSubstring, assumingly to distinguish it from the containers' Contains. Adapt accordingly.

Also use the same matcher in the XML writer test.