### PR TITLE
Remove unnecessary ns prefix `tacos::` if we have imported the ns

### DIFF
--- a/test/railroad_location.cpp
+++ b/test/railroad_location.cpp
@@ -52,11 +52,11 @@ create_disjunction(const std::vector<ProductLocation> &disjuncts)
 	return disjunction;
 }
 
-std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
-           tacos::logic::MTLFormula<
-             tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::string>::Location>,
-           std::set<std::string>,
-           std::set<std::string>>
+std::tuple<
+  automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
+  logic::MTLFormula<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>::Location>,
+  std::set<std::string>,
+  std::set<std::string>>
 create_crossing_problem(std::vector<Time> distances)
 {
 	std::vector<TA>         automata;
@@ -134,10 +134,10 @@ create_crossing_problem(std::vector<Time> distances)
 	                      train_transitions});
 	environment_actions.insert(std::begin(train_actions), std::end(train_actions));
 	for (std::size_t i = 1; i < automata.size(); i++) {
-		tacos::visualization::ta_to_graphviz(automata[i - 1])
+		visualization::ta_to_graphviz(automata[i - 1])
 		  .render_to_file(fmt::format("railroad{}_crossing_{}.pdf", distances.size(), i));
 	}
-	tacos::visualization::ta_to_graphviz(automata.back())
+	visualization::ta_to_graphviz(automata.back())
 	  .render_to_file(fmt::format("railroad{}_train.pdf", distances.size()));
 
 	auto                         product_automaton = automata::ta::get_product(automata);

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -82,14 +82,13 @@ TEST_CASE("Create a simple controller", "[.][controller]")
 	search.build_tree();
 	// search.label();
 #ifdef HAVE_VISUALIZATION
-	tacos::visualization::search_tree_to_graphviz(*search.get_root())
-	  .render_to_file("simple_tree.svg");
-	tacos::visualization::ta_to_graphviz(ta).render_to_file("simple_plant.svg");
+	visualization::search_tree_to_graphviz(*search.get_root()).render_to_file("simple_tree.svg");
+	visualization::ta_to_graphviz(ta).render_to_file("simple_plant.svg");
 #endif
 	const auto controller =
 	  controller_synthesis::create_controller(search.get_root(), {"c"}, {"e"}, 2);
 	CAPTURE(controller);
-	tacos::visualization::ta_to_graphviz(controller, false).render_to_file("simple_controller.svg");
+	visualization::ta_to_graphviz(controller, false).render_to_file("simple_controller.svg");
 	CHECK(search.get_root()->label == search::NodeLabel::TOP);
 }
 
@@ -135,7 +134,7 @@ TEST_CASE("Controller time bounds", "[.railroad][controller]")
 	                                    4);
 
 #ifdef HAVE_VISUALIZATION
-	tacos::visualization::ta_to_graphviz(controller).render_to_file("railroad_bounds_controller.svg");
+	visualization::ta_to_graphviz(controller).render_to_file("railroad_bounds_controller.svg");
 #endif
 
 	// TODO Check more properties of the controller

--- a/test/test_fischer.cpp
+++ b/test/test_fischer.cpp
@@ -85,13 +85,10 @@ TEST_CASE("Two processes", "[.large][fisher]")
 	search.build_tree(true);
 	INFO("Tree:\n" << search::node_to_string(*search.get_root(), true));
 #ifdef HAVE_VISUALIZATION
-	tacos::visualization::search_tree_to_graphviz(*search.get_root(), true)
-	  .render_to_file("fischer2.svg");
-	tacos::visualization::ta_to_graphviz(product).render_to_file("fischer2_ta.svg");
-	tacos::visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(),
-	                                                                             controller_actions,
-	                                                                             environment_actions,
-	                                                                             K))
+	visualization::search_tree_to_graphviz(*search.get_root(), true).render_to_file("fischer2.svg");
+	visualization::ta_to_graphviz(product).render_to_file("fischer2_ta.svg");
+	visualization::ta_to_graphviz(controller_synthesis::create_controller(
+	                                search.get_root(), controller_actions, environment_actions, K))
 	  .render_to_file("fischer2_controller.svg");
 #endif
 	CHECK(search.get_root()->label == NodeLabel::TOP);

--- a/test/test_golog_search.cpp
+++ b/test/test_golog_search.cpp
@@ -37,12 +37,13 @@
 
 namespace {
 
-using namespace tacos::logic;
-using tacos::search::GologConfiguration;
-using tacos::search::GologLocation;
-using tacos::search::GologProgram;
-using tacos::search::LabelReason;
-using tacos::search::NodeLabel;
+using namespace tacos;
+using namespace logic;
+using search::GologConfiguration;
+using search::GologLocation;
+using search::GologProgram;
+using search::LabelReason;
+using search::NodeLabel;
 
 using AP = AtomicProposition<std::string>;
 
@@ -55,7 +56,7 @@ TEST_CASE("Initialize Golog programs", "[golog]")
     procedure main() { say(); }
   )");
 	const auto   initial_configuration = program.get_initial_configuration();
-	CHECK(initial_configuration.clock_valuations == tacos::ClockSetValuation{{"golog", 0}});
+	CHECK(initial_configuration.clock_valuations == ClockSetValuation{{"golog", 0}});
 }
 
 TEST_CASE("Compare GologLocations", "[golog]")
@@ -126,14 +127,12 @@ TEST_CASE("Search on a simple golog program", "[golog][search]")
 	               end(actions),
 	               std::inserter(action_aps, end(action_aps)),
 	               [](const auto &action) { return AP{action}; });
-	auto ata = tacos::mtl_ata_translation::translate(f, action_aps);
+	auto ata = mtl_ata_translation::translate(f, action_aps);
 	CAPTURE(ata);
-	tacos::search::
-	  TreeSearch<tacos::search::GologLocation, std::string, std::string, false, GologProgram>
-	    search(&program, &ata, controller_actions, environment_actions, 1, true, false);
+	search::TreeSearch<search::GologLocation, std::string, std::string, false, GologProgram> search(
+	  &program, &ata, controller_actions, environment_actions, 1, true, false);
 	search.build_tree(false);
-	tacos::visualization::search_tree_to_graphviz(*search.get_root())
-	  .render_to_file("golog_tree.png");
+	visualization::search_tree_to_graphviz(*search.get_root()).render_to_file("golog_tree.png");
 
 	CHECK(search.get_nodes().size() == 12);
 	// 4 for start(hear()) and 1 for env_terminate.

--- a/test/test_golog_words.cpp
+++ b/test/test_golog_words.cpp
@@ -32,11 +32,13 @@
 
 namespace {
 
-using tacos::search::get_next_canonical_words;
-using tacos::search::GologProgram;
-using namespace tacos::logic;
+using namespace tacos;
+using namespace logic;
 
-using CanonicalABWord = tacos::search::CanonicalABWord<tacos::search::GologLocation, std::string>;
+using search::get_next_canonical_words;
+using search::GologProgram;
+
+using CanonicalABWord = search::CanonicalABWord<search::GologLocation, std::string>;
 
 TEST_CASE("Golog successors", "[golog]")
 {
@@ -46,13 +48,12 @@ TEST_CASE("Golog successors", "[golog]")
   )");
 	const auto   f = finally(MTLFormula<std::string>{std::string{"end(say())"}});
 	const auto   ata =
-	  tacos::mtl_ata_translation::translate(f,
-	                                        {std::string{"start(say())"}, std::string{"end(say())"}});
+	  mtl_ata_translation::translate(f, {std::string{"start(say())"}, std::string{"end(say())"}});
 	CAPTURE(ata);
-	tacos::search::GologConfiguration golog_configuration = program.get_initial_configuration();
-	const std::set<std::string>       controller_actions  = {"start(say())"};
-	const std::set<std::string>       environment_actions = {"end(say())"};
-	const auto                        next_words =
+	search::GologConfiguration  golog_configuration = program.get_initial_configuration();
+	const std::set<std::string> controller_actions  = {"start(say())"};
+	const std::set<std::string> environment_actions = {"end(say())"};
+	const auto                  next_words =
 	  get_next_canonical_words<GologProgram, std::string, std::string, false>(controller_actions,
 	                                                                          environment_actions)(
 	    program, ata, {golog_configuration, ata.get_initial_configuration()}, 0, 2);
@@ -62,7 +63,7 @@ TEST_CASE("Golog successors", "[golog]")
 	CHECK(next_words.begin()->first == "start(say())");
 	CHECK(next_words.begin()->second.size() == 1);
 	for (const auto &ab_symbol : next_words.begin()->second.front()) {
-		using GologSymbol = tacos::search::PlantRegionState<tacos::search::GologLocation>;
+		using GologSymbol = search::PlantRegionState<search::GologLocation>;
 		if (std::holds_alternative<GologSymbol>(ab_symbol)) {
 			const auto &golog_symbol = std::get<GologSymbol>(ab_symbol);
 			CHECK(golog_symbol.location.history->special_semantics().as_transitions().size() == 1);
@@ -71,8 +72,8 @@ TEST_CASE("Golog successors", "[golog]")
 			CHECK(golog_symbol.clock == "golog");
 			CHECK(golog_symbol.region_index == 0);
 		} else {
-			REQUIRE(std::holds_alternative<tacos::search::ATARegionState<std::string>>(ab_symbol));
-			const auto &ata_symbol = std::get<tacos::search::ATARegionState<std::string>>(ab_symbol);
+			REQUIRE(std::holds_alternative<search::ATARegionState<std::string>>(ab_symbol));
+			const auto &ata_symbol = std::get<search::ATARegionState<std::string>>(ab_symbol);
 			CHECK(ata_symbol.formula == f);
 			CHECK(ata_symbol.region_index == 0);
 		}

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -35,7 +35,7 @@ using namespace tacos;
 
 using logic::MTLFormula;
 using logic::TimeInterval;
-using tacos::mtl_ata_translation::translate;
+using mtl_ata_translation::translate;
 using utilities::arithmetic::BoundType;
 
 using AP = logic::AtomicProposition<std::string>;
@@ -318,9 +318,9 @@ TEST_CASE("MTL ATA Translation exceptions", "[translator][exceptions]")
 
 TEST_CASE("MTL ATA sink location", "[translator][sink]")
 {
-	using Configuration = tacos::automata::ata::Configuration<MTLFormula<std::string>>;
-	using State         = tacos::automata::ata::State<MTLFormula<std::string>>;
-	// using Run           = tacos::automata::ata::Run<MTLFormula<std::string>, std::string>;
+	using Configuration = automata::ata::Configuration<MTLFormula<std::string>>;
+	using State         = automata::ata::State<MTLFormula<std::string>>;
+	// using Run           = automata::ata::Run<MTLFormula<std::string>, std::string>;
 	const std::string a_symbol{"a"};
 	const std::string b_symbol{"b"};
 	const std::string c_symbol{"c"};

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -88,13 +88,11 @@ TEST_CASE("Railroad", "[railroad]")
 	search.build_tree(true);
 	CHECK(search.get_root()->label == NodeLabel::TOP);
 #ifdef HAVE_VISUALIZATION
-	tacos::visualization::search_tree_to_graphviz(*search.get_root(), true)
+	visualization::search_tree_to_graphviz(*search.get_root(), true)
 	  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
-	tacos::visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(),
-	                                                                             controller_actions,
-	                                                                             environment_actions,
-	                                                                             2),
-	                                     false)
+	visualization::ta_to_graphviz(controller_synthesis::create_controller(
+	                                search.get_root(), controller_actions, environment_actions, 2),
+	                              false)
 	  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
 #endif
 }
@@ -149,12 +147,11 @@ TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 		search.build_tree(true);
 		CHECK(search.get_root()->label == NodeLabel::TOP);
 #ifdef HAVE_VISUALIZATION
-		tacos::visualization::search_tree_to_graphviz(*search.get_root(), true)
+		visualization::search_tree_to_graphviz(*search.get_root(), true)
 		  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
-		tacos::visualization::ta_to_graphviz(
-		  controller_synthesis::create_controller(
-		    search.get_root(), controller_actions, environment_actions, 2),
-		  false)
+		visualization::ta_to_graphviz(controller_synthesis::create_controller(
+		                                search.get_root(), controller_actions, environment_actions, 2),
+		                              false)
 		  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
 #endif
 	};

--- a/test/test_railroad_location.cpp
+++ b/test/test_railroad_location.cpp
@@ -113,13 +113,11 @@ TEST_CASE("Railroad with two crossings", "[.railroad]")
 	search.build_tree(true);
 	SPDLOG_DEBUG("Search completed!");
 	CHECK(search.get_root()->label == NodeLabel::TOP);
-	tacos::visualization::ta_to_graphviz(controller_synthesis::create_controller(search.get_root(),
-	                                                                             controller_actions,
-	                                                                             environment_actions,
-	                                                                             2),
-	                                     false)
+	visualization::ta_to_graphviz(controller_synthesis::create_controller(
+	                                search.get_root(), controller_actions, environment_actions, 2),
+	                              false)
 	  .render_to_file(fmt::format("railroad{}_controller.pdf", num_crossings));
-	tacos::visualization::search_tree_to_graphviz(*search.get_root(), true)
+	visualization::search_tree_to_graphviz(*search.get_root(), true)
 	  .render_to_file(fmt::format("railroad{}.svg", num_crossings));
 }
 

--- a/test/test_ta_visualization.cpp
+++ b/test/test_ta_visualization.cpp
@@ -31,7 +31,7 @@ using namespace tacos;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
 using Location   = automata::ta::Location<std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
-using tacos::visualization::ta_to_graphviz;
+using visualization::ta_to_graphviz;
 
 using Catch::Matchers::ContainsSubstring;
 TEST_CASE("Visualize a TA", "[visualization]")

--- a/test/test_tree_visualization.cpp
+++ b/test/test_tree_visualization.cpp
@@ -97,7 +97,7 @@ read_file(const std::filesystem::path &file)
 TEST_CASE("Search tree visualization", "[search][visualization]")
 {
 	auto root  = create_test_graph();
-	auto graph = tacos::visualization::search_tree_to_graphviz(*root);
+	auto graph = visualization::search_tree_to_graphviz(*root);
 	graph.render_to_file("test_tree_visualization.png");
 	const auto dot = graph.to_dot();
 


### PR DESCRIPTION
There is no need to prefix every member with the namespace prefix if we
have already imported the complete namespace with a using-directive.

This is a follow-up to #124.