### PR TITLE
mtl: an interval endpoint must be uint, not double

### DIFF
--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -38,7 +38,6 @@
 namespace tacos::automata {
 
 using Symbol    = std::string;
-using Endpoint  = unsigned int;
 using TimedWord = std::vector<std::pair<Symbol, Time>>;
 
 template <typename Comp>

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -450,7 +450,7 @@ public:
 	 * @brief Get the largest constant any clock is compared to.
 	 * @return Time
 	 */
-	Time get_largest_constant() const;
+	Endpoint get_largest_constant() const;
 
 	/** Get the initial configuration of the automaton.
 	 * @return The initial configuration

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -279,7 +279,7 @@ TimedAutomaton<LocationT, AP>::get_enabled_transitions(
 }
 
 template <typename LocationT, typename AP>
-Time
+Endpoint
 TimedAutomaton<LocationT, AP>::get_largest_constant() const
 {
 	Time res{0};

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -35,9 +35,9 @@
 namespace tacos::logic {
 
 /// An interval endpoint used for constrained until and dual until operators.
-using TimePoint = double;
+using Endpoint = unsigned int;
 /// An interval used for constrained until and dual until operators.
-using TimeInterval = utilities::arithmetic::Interval<TimePoint>;
+using TimeInterval = utilities::arithmetic::Interval<Endpoint>;
 
 template <typename APType>
 class MTLFormula;
@@ -122,7 +122,7 @@ public:
 	/**
 	 * @brief Constructor
 	 */
-	MTLWord(std::initializer_list<std::pair<std::vector<AtomicProposition<APType>>, TimePoint>> a)
+	MTLWord(std::initializer_list<std::pair<std::vector<AtomicProposition<APType>>, Endpoint>> a)
 	: word_(a)
 	{
 	}
@@ -138,7 +138,7 @@ public:
 	bool satisfies(const MTLFormula<APType> &phi) const;
 
 private:
-	std::vector<std::pair<std::vector<AtomicProposition<APType>>, TimePoint>> word_;
+	std::vector<std::pair<std::vector<AtomicProposition<APType>>, Endpoint>> word_;
 };
 
 /**
@@ -300,7 +300,7 @@ public:
 	}
 
 	/** Get the value of the largest constant occurring in the formula.  */
-	TimePoint get_largest_constant() const;
+	Endpoint get_largest_constant() const;
 
 	// TODO Refactor into utilities.
 	/** Get the value of the largest constant occurring in the formula.  */

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -21,6 +21,7 @@
 #define SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 
 #include "utilities/Interval.h"
+#include "utilities/types.h"
 
 #include <algorithm>
 #include <cassert>
@@ -34,8 +35,6 @@
 /// MTLFormulas and types related to MTL.
 namespace tacos::logic {
 
-/// An interval endpoint used for constrained until and dual until operators.
-using Endpoint = unsigned int;
 /// An interval used for constrained until and dual until operators.
 using TimeInterval = utilities::arithmetic::Interval<Endpoint>;
 

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -358,10 +358,10 @@ MTLFormula<APType>::get_subformulas_of_type(LOP op) const
 }
 
 template <typename APType>
-TimePoint
+Endpoint
 MTLFormula<APType>::get_largest_constant() const
 {
-	TimePoint largest_constant = 0;
+	Endpoint largest_constant = 0;
 	switch (operator_) {
 	case LOP::AP:
 	case LOP::TRUE:
@@ -370,7 +370,7 @@ MTLFormula<APType>::get_largest_constant() const
 	case LOP::LAND:
 	case LOP::LOR:
 		for (const auto &sub_formula : operands_) {
-			largest_constant = std::max(0., sub_formula.get_largest_constant());
+			largest_constant = std::max(0u, sub_formula.get_largest_constant());
 		}
 		break;
 	case LOP::LUNTIL:

--- a/src/mtl/mtl.proto
+++ b/src/mtl/mtl.proto
@@ -33,7 +33,7 @@ message MTLFormula {
       STRICT = 1;
     }
     message Endpoint {
-      double value = 1;
+      uint32 value = 1;
       BoundType bound_type = 2;
     }
     Endpoint lower = 1;

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -35,10 +35,10 @@ namespace tacos::mtl_ata_translation {
 
 using namespace automata;
 using logic::AtomicProposition;
+using logic::Endpoint;
 using logic::LOP;
 using logic::MTLFormula;
 using logic::TimeInterval;
-using logic::TimePoint;
 
 ///@{
 /// Formulas are always ATA formulas over MTLFormulas.
@@ -97,19 +97,19 @@ create_contains(TimeInterval duration)
 	if (duration.lowerBoundType() != BoundType::INFTY) {
 		if (duration.lowerBoundType() == BoundType::WEAK) {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater_equal<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::greater_equal<Time>>(duration.lower()));
 		} else {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::greater<Time>>(duration.lower()));
 		}
 	}
 	if (duration.upperBoundType() != BoundType::INFTY) {
 		if (duration.upperBoundType() == BoundType::WEAK) {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less_equal<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::less_equal<Time>>(duration.upper()));
 		} else {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::less<Time>>(duration.upper()));
 		}
 	}
 	return ata::create_conjunction(std::move(lowerBound), std::move(upperBound));
@@ -127,19 +127,19 @@ create_negated_contains(TimeInterval duration)
 	if (duration.lowerBoundType() != BoundType::INFTY) {
 		if (duration.lowerBoundType() == BoundType::WEAK) {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::less<Time>>(duration.lower()));
 		} else {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less_equal<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::less_equal<Time>>(duration.lower()));
 		}
 	}
 	if (duration.upperBoundType() != BoundType::INFTY) {
 		if (duration.upperBoundType() == BoundType::WEAK) {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::greater<Time>>(duration.upper()));
 		} else {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater_equal<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::greater_equal<Time>>(duration.upper()));
 		}
 	}
 	return ata::create_disjunction(std::move(lowerBound), std::move(upperBound));

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -35,7 +35,6 @@ namespace tacos::mtl_ata_translation {
 
 using namespace automata;
 using logic::AtomicProposition;
-using logic::Endpoint;
 using logic::LOP;
 using logic::MTLFormula;
 using logic::TimeInterval;

--- a/src/utilities/include/utilities/types.h
+++ b/src/utilities/include/utilities/types.h
@@ -27,6 +27,7 @@ namespace tacos {
 
 using RegionIndex    = unsigned int;
 using Time           = double;
+using Endpoint       = unsigned int;
 using ClockValuation = Time;
 
 /// A clock of a plant.

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -18,6 +18,7 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include "automata/automata.h"
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"
 
@@ -224,10 +225,10 @@ TEST_CASE("MTL Formula comparison operators", "[libmtl]")
 	CHECK(phi3 < (phi1 && phi5));
 
 	CHECK(phi1.until(phi2)
-	      != phi1.until(phi2, utilities::arithmetic::Interval<logic::TimePoint>{0, 1}));
+	      != phi1.until(phi2, utilities::arithmetic::Interval<automata::Endpoint>{0, 1}));
 
 	CHECK(phi1.dual_until(phi2)
-	      != phi1.dual_until(phi2, utilities::arithmetic::Interval<logic::TimePoint>{1, 2}));
+	      != phi1.dual_until(phi2, utilities::arithmetic::Interval<automata::Endpoint>{1, 2}));
 }
 
 TEST_CASE("Get subformulas of type", "[libmtl]")

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -18,9 +18,9 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include "automata/automata.h"
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"
+#include "utilities/types.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <iostream>
@@ -29,7 +29,6 @@
 namespace {
 
 using namespace tacos;
-
 using logic::finally;
 using logic::globally;
 
@@ -224,11 +223,10 @@ TEST_CASE("MTL Formula comparison operators", "[libmtl]")
 	CHECK(phi1 > phi4);
 	CHECK(phi3 < (phi1 && phi5));
 
-	CHECK(phi1.until(phi2)
-	      != phi1.until(phi2, utilities::arithmetic::Interval<automata::Endpoint>{0, 1}));
+	CHECK(phi1.until(phi2) != phi1.until(phi2, utilities::arithmetic::Interval<Endpoint>{0, 1}));
 
 	CHECK(phi1.dual_until(phi2)
-	      != phi1.dual_until(phi2, utilities::arithmetic::Interval<automata::Endpoint>{1, 2}));
+	      != phi1.dual_until(phi2, utilities::arithmetic::Interval<Endpoint>{1, 2}));
 }
 
 TEST_CASE("Get subformulas of type", "[libmtl]")


### PR DESCRIPTION
Consistently use `Endpoint` where we are referring to an Endpoint (rather than Time).

Also remove duplicate definitions of Endpoint and move the definition to the `utilities/types.h` header.

This was noticed during the review for #124.