### PR TITLE
Introduce better typedefs for ATAs

### DIFF
--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -54,8 +54,14 @@ public:
 template <typename LocationT>
 using Configuration = std::set<State<LocationT>>;
 
+template <typename SymbolT>
+using RunStep = std::variant<SymbolT, Time>;
+
 template <typename LocationT, typename SymbolT>
-using Run = std::vector<std::pair<std::variant<SymbolT, Time>, Configuration<LocationT>>>;
+using RunComponent = std::pair<RunStep<SymbolT>, Configuration<LocationT>>;
+
+template <typename LocationT, typename SymbolT>
+using Run = std::vector<RunComponent<LocationT, SymbolT>>;
 
 template <typename LocationT, typename SymbolT>
 class AlternatingTimedAutomaton;

--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -31,6 +31,11 @@
 
 namespace tacos::automata::ata {
 
+template <typename SymbolT = std::string>
+using TimedATASymbol = std::pair<SymbolT, Time>;
+template <typename SymbolT = std::string>
+using TimedATAWord = std::vector<TimedATASymbol<SymbolT>>;
+
 /// Thrown if the wrong ATA transition type is attempted
 class WrongTransitionTypeException : public std::logic_error
 {
@@ -225,7 +230,7 @@ public:
 	 * @param word The timed word to check
 	 * @return true if the given word is accepted
 	 */
-	[[nodiscard]] bool accepts_word(const TimedWord &word) const;
+	[[nodiscard]] bool accepts_word(const TimedATAWord<SymbolT> &word) const;
 
 	/** Print an AlternatingTimedAutomaton to an ostream
 	 * @param os The ostream to print to

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -312,7 +312,7 @@ AlternatingTimedAutomaton<LocationT, SymbolT>::is_accepting_configuration(
 
 template <typename LocationT, typename SymbolT>
 [[nodiscard]] bool
-AlternatingTimedAutomaton<LocationT, SymbolT>::accepts_word(const TimedWord &word) const
+AlternatingTimedAutomaton<LocationT, SymbolT>::accepts_word(const TimedATAWord<SymbolT> &word) const
 {
 	if (word.size() == 0) {
 		return false;

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -39,79 +39,83 @@ using mtl_ata_translation::translate;
 using utilities::arithmetic::BoundType;
 
 using AP = logic::AtomicProposition<std::string>;
+// using Word = automata::ata::TimedATAWord<AP>;
+
+const AP a{"a"};
+const AP b{"b"};
+const AP c{"c"};
+const AP d{"d"};
 
 TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 {
 	spdlog::set_level(spdlog::level::trace);
-	const MTLFormula a{AP{"a"}};
-	const MTLFormula b{AP{"b"}};
-	const MTLFormula c{AP{"c"}};
-	const MTLFormula d{AP{"d"}};
 
 	SECTION("A simple until formula")
 	{
-		const MTLFormula phi = a.until(b);
+		const MTLFormula phi = MTLFormula{a}.until(b);
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 2.5}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 1.5}}));
-		CHECK(!ata.accepts_word({{"c", 0}, {"b", 1.5}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1.5}}));
-		CHECK(!ata.accepts_word({{"b", 0}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 0}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 1}, {b, 2.5}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 1}, {b, 1.5}}));
+		CHECK(!ata.accepts_word({{c, 0}, {b, 1.5}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1.5}}));
+		CHECK(!ata.accepts_word({{b, 0}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 0}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 1}}));
 	}
 
 	SECTION("True literal in MTL formula")
 	{
 		const MTLFormula phi = MTLFormula<std::string>::TRUE().until(b);
-		const auto       ata = translate(phi, {AP{"a"}, AP{"b"}});
+		const auto       ata = translate(phi, {AP{a}, AP{b}});
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 2}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"a", 2}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 1}, {b, 2}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 1}, {a, 2}}));
 	}
 
 	SECTION("False literal in MTL formula")
 	{
 		const MTLFormula phi = MTLFormula<std::string>::FALSE().until(b);
-		const auto       ata = translate(phi, {AP{"a"}, AP{"b"}});
+		const auto       ata = translate(phi, {AP{a}, AP{b}});
 		INFO("ATA:\n" << ata);
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 2}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 2}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 1}, {b, 2}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 2}}));
 	}
 
 	SECTION("An until formula with time bounds")
 	{
-		const MTLFormula phi = a.until(b, TimeInterval(2, 3));
+		const MTLFormula phi = MTLFormula{a}.until(b, TimeInterval(2, 3));
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 3}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 2.9}, {"b", 3}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 3.1}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 5}, {"b", 7}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.1}, {"b", 1.9}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.5}, {b, 2}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 1}, {b, 3}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 2.9}, {b, 3}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 1}, {b, 3.1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 5}, {b, 7}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 0.1}, {b, 1.9}}));
 	}
 
 	SECTION("An until formula with strict lower time bound")
 	{
-		const MTLFormula phi = a.until(b, TimeInterval(2, BoundType::STRICT, 2, BoundType::INFTY));
-		const auto       ata = translate(phi);
+		const MTLFormula phi =
+		  MTLFormula{a}.until(b, TimeInterval(2, BoundType::STRICT, 2, BoundType::INFTY));
+		const auto ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2.1}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"a", 5}, {"a", 10}, {"b", 12}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 12}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.1}, {"b", 12}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.5}, {b, 2.1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 0.5}, {b, 2}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.5}, {a, 5}, {a, 10}, {b, 12}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 12}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.1}, {b, 12}}));
 	}
 
 	SECTION("An until formula with strict upper bound")
 	{
-		const MTLFormula phi = a.until(b, TimeInterval(2, BoundType::WEAK, 3, BoundType::STRICT));
-		const auto       ata = translate(phi);
+		const MTLFormula phi =
+		  MTLFormula{a}.until(b, TimeInterval(2, BoundType::WEAK, 3, BoundType::STRICT));
+		const auto ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"b", 2}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 3}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.5}, {b, 2}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 1}, {b, 3}}));
 	}
 
 	SECTION("An until with a negation")
@@ -120,8 +124,8 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
 		// TODO(morxa) this is broken because there is no c in the automaton
-		// CHECK(ata.accepts_word({{"c", 0}, {"c", 1}, {"b", 2.5}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 1}, {"b", 1.5}}));
+		// CHECK(ata.accepts_word({{c, 0}, {c, 1}, {b, 2.5}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 1}, {b, 1.5}}));
 	}
 
 	SECTION("An until with a disjunctive subformula")
@@ -129,9 +133,9 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		const MTLFormula phi = (a || b).until(c);
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 0.5}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"a", 0.5}, {"b", 0.8}, {"c", 1}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.5}, {c, 1}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 0.5}, {c, 1}}));
+		CHECK(ata.accepts_word({{b, 0}, {a, 0.5}, {b, 0.8}, {c, 1}}));
 	}
 
 	SECTION("An until with a conjunctive subformula")
@@ -139,9 +143,9 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		const MTLFormula phi = (a && b).until(c);
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 0.5}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"c", 0.5}, {"c", 1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 0.5}, {c, 1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 0.5}, {c, 1}}));
+		CHECK(ata.accepts_word({{a, 0}, {c, 0.5}, {c, 1}}));
 	}
 
 	SECTION("An until with a conjunctive subformula with negations")
@@ -149,11 +153,11 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		const MTLFormula phi = (!a && !b).until(c);
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 0.5}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"c", 0}, {"c", 0.5}, {"c", 1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 0.5}, {c, 1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 0.5}, {c, 1}}));
+		CHECK(ata.accepts_word({{c, 0}, {c, 0.5}, {c, 1}}));
 		// TODO(morxa) this is broken because there is no c in the automaton
-		// CHECK(ata.accepts_word({{"a", 0}, {"d", 0.5}, {"c", 1}}));
+		// CHECK(ata.accepts_word({{a, 0}, {d, 0.5}, {c, 1}}));
 	}
 
 	SECTION("An until with a negation of a non-atomic formula")
@@ -161,94 +165,95 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		const MTLFormula phi = (!(a && b)).until(c);
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"a", 0.5}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 0.5}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"c", 0}, {"c", 0.5}, {"c", 1}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"a", 0.5}, {"a", 1}}));
+		CHECK(ata.accepts_word({{a, 0}, {a, 0.5}, {c, 1}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 0.5}, {c, 1}}));
+		CHECK(ata.accepts_word({{c, 0}, {c, 0.5}, {c, 1}}));
+		CHECK(!ata.accepts_word({{a, 0}, {a, 0.5}, {a, 1}}));
 	}
 
 	SECTION("Nested until")
 	{
-		const MTLFormula phi = a.until(b.until(c));
+		const MTLFormula phi = MTLFormula{a}.until(MTLFormula{b}.until(c));
 		const auto       ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"c", 3}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"c", 1}, {"b", 1}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {c, 3}}));
+		CHECK(!ata.accepts_word({{a, 0}, {c, 1}, {b, 1}}));
 	}
 
 	SECTION("Nested until with time bounds")
 	{
-		const MTLFormula phi = a.until(b.until(c, TimeInterval(1, 2)), TimeInterval(0, 1));
-		const auto       ata = translate(phi);
+		const MTLFormula phi =
+		  MTLFormula{a}.until(MTLFormula{b}.until(c, TimeInterval(1, 2)), TimeInterval(0, 1));
+		const auto ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"c", 3}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"c", 1.5}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {c, 3}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {c, 1.5}}));
 	}
 
 	SECTION("Dual until")
 	{
-		const MTLFormula phi = a.dual_until(b);
+		const MTLFormula phi = MTLFormula{a}.dual_until(b);
 		// ~ (~a U ~b)
 		const auto ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"b", 0}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 2}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 2}, {"b", 3}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
+		CHECK(ata.accepts_word({{b, 0}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 1}, {b, 2}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 1}, {b, 2}, {b, 3}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 2}, {b, 3}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 2}, {b, 3}, {a, 4}}));
 	}
 
 	SECTION("Dual until with time bounds")
 	{
-		const MTLFormula phi = a.dual_until(b, TimeInterval(2, 3));
+		const MTLFormula phi = MTLFormula{a}.dual_until(b, TimeInterval(2, 3));
 		// ~ (~a U ~b)
 		const auto ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 3.0}, {"b", 4}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.0}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.1}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"a", 2.5}, {"b", 4}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.0}, {"b", 4}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 1}, {b, 3.0}, {b, 4}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 3.0}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 3.1}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 1.9}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 1.9}, {a, 2.5}, {b, 4}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 2.0}, {b, 4}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 2}, {b, 3}, {a, 4}}));
 	}
 
 	SECTION("Dual until with strict time bounds")
 	{
 		const MTLFormula phi =
-		  a.dual_until(b, TimeInterval(2, BoundType::STRICT, 3, BoundType::STRICT));
+		  MTLFormula{a}.dual_until(b, TimeInterval(2, BoundType::STRICT, 3, BoundType::STRICT));
 		// ~ (~a U ~b)
 		const auto ata = translate(phi);
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"b", 0}, {"b", 1}, {"b", 3.0}, {"b", 4}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.9}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.0}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 3.1}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 1.9}, {"a", 2.5}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.0}, {"b", 4}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2.1}, {"b", 4}}));
-		CHECK(ata.accepts_word({{"a", 0}, {"b", 1}, {"a", 2}, {"b", 3}, {"a", 4}}));
+		CHECK(ata.accepts_word({{b, 0}, {b, 1}, {b, 3.0}, {b, 4}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 2.9}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 3.0}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 3.1}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 1.9}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 1.9}, {a, 2.5}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 2.0}, {b, 4}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}, {a, 2.1}, {b, 4}}));
+		CHECK(ata.accepts_word({{a, 0}, {b, 1}, {a, 2}, {b, 3}, {a, 4}}));
 	}
 
 	SECTION("Single negation operation")
 	{
 		const MTLFormula phi             = !a;
-		const auto       ata             = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const auto       ata             = translate(phi, {AP(a), AP(b), AP(c), AP(d)});
 		const auto       ata_no_alphabet = translate(phi);
 
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"b", 0}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"c", 1}}));
-		CHECK(ata.accepts_word({{"b", 0}, {"a", 1}}));
-		CHECK(!ata.accepts_word({{"a", 0}}));
-		CHECK(!ata.accepts_word({{"a", 0}, {"b", 1}}));
+		CHECK(ata.accepts_word({{b, 0}}));
+		CHECK(ata.accepts_word({{b, 0}, {c, 1}}));
+		CHECK(ata.accepts_word({{b, 0}, {a, 1}}));
+		CHECK(!ata.accepts_word({{a, 0}}));
+		CHECK(!ata.accepts_word({{a, 0}, {b, 1}}));
 
-		CHECK(!ata_no_alphabet.accepts_word({{"b", 0}}));
-		CHECK(!ata_no_alphabet.accepts_word({{"b", 0}, {"c", 1}}));
-		CHECK(!ata_no_alphabet.accepts_word({{"b", 0}, {"a", 1}}));
-		CHECK(!ata_no_alphabet.accepts_word({{"a", 0}}));
-		CHECK(!ata_no_alphabet.accepts_word({{"a", 0}, {"b", 1}}));
+		CHECK(!ata_no_alphabet.accepts_word({{b, 0}}));
+		CHECK(!ata_no_alphabet.accepts_word({{b, 0}, {c, 1}}));
+		CHECK(!ata_no_alphabet.accepts_word({{b, 0}, {a, 1}}));
+		CHECK(!ata_no_alphabet.accepts_word({{a, 0}}));
+		CHECK(!ata_no_alphabet.accepts_word({{a, 0}, {b, 1}}));
 	}
 
 	SECTION("Single conjunction of two different APs")
@@ -256,57 +261,57 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 		// TODO Conjunction of AP does not really make sense, since we can only read single symbols on a
 		// transition
 		const MTLFormula phi = a && b;
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c), AP(d)});
 
 		INFO("ATA:\n" << ata);
-		CHECK(!ata.accepts_word({{"b", 0}}));
-		CHECK(!ata.accepts_word({{"a", 0}}));
+		CHECK(!ata.accepts_word({{b, 0}}));
+		CHECK(!ata.accepts_word({{a, 0}}));
 	}
 
 	SECTION("Single conjunction of two similar APs")
 	{
 		const MTLFormula phi = a && a;
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c), AP(d)});
 
 		INFO("ATA:\n" << ata);
-		CHECK(!ata.accepts_word({{"b", 0}}));
-		CHECK(ata.accepts_word({{"a", 0}}));
+		CHECK(!ata.accepts_word({{b, 0}}));
+		CHECK(ata.accepts_word({{a, 0}}));
 	}
 
 	SECTION("Single disjunction of two APs")
 	{
 		const MTLFormula phi = a || b;
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c), AP(d)});
 
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"b", 0}}));
-		CHECK(ata.accepts_word({{"a", 0}}));
-		CHECK(!ata.accepts_word({{"c", 0}}));
-		CHECK(!ata.accepts_word({{"d", 0}}));
+		CHECK(ata.accepts_word({{b, 0}}));
+		CHECK(ata.accepts_word({{a, 0}}));
+		CHECK(!ata.accepts_word({{c, 0}}));
+		CHECK(!ata.accepts_word({{d, 0}}));
 	}
 
 	SECTION("Simple tautology")
 	{
-		const MTLFormula phi = a || !a;
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const MTLFormula phi = MTLFormula{a} || !a;
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c), AP(d)});
 
 		INFO("ATA:\n" << ata);
-		CHECK(ata.accepts_word({{"b", 0}}));
-		CHECK(ata.accepts_word({{"a", 0}}));
-		CHECK(ata.accepts_word({{"c", 0}}));
-		CHECK(ata.accepts_word({{"d", 0}}));
+		CHECK(ata.accepts_word({{b, 0}}));
+		CHECK(ata.accepts_word({{a, 0}}));
+		CHECK(ata.accepts_word({{c, 0}}));
+		CHECK(ata.accepts_word({{d, 0}}));
 	}
 
 	SECTION("Simple unsatisfiable ata")
 	{
-		const MTLFormula phi = a && !a;
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c"), AP("d")});
+		const MTLFormula phi = MTLFormula{a} && !a;
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c), AP(d)});
 
 		INFO("ATA:\n" << ata);
-		CHECK(!ata.accepts_word({{"b", 0}}));
-		CHECK(!ata.accepts_word({{"a", 0}}));
-		CHECK(!ata.accepts_word({{"c", 0}}));
-		CHECK(!ata.accepts_word({{"d", 0}}));
+		CHECK(!ata.accepts_word({{b, 0}}));
+		CHECK(!ata.accepts_word({{a, 0}}));
+		CHECK(!ata.accepts_word({{c, 0}}));
+		CHECK(!ata.accepts_word({{d, 0}}));
 	}
 }
 
@@ -321,22 +326,22 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 	using Configuration = automata::ata::Configuration<MTLFormula<std::string>>;
 	using State         = automata::ata::State<MTLFormula<std::string>>;
 	// using Run           = automata::ata::Run<MTLFormula<std::string>, std::string>;
-	const std::string a_symbol{"a"};
-	const std::string b_symbol{"b"};
-	const std::string c_symbol{"c"};
-	const MTLFormula  a{AP{"a"}};
-	const MTLFormula  b{AP{"b"}};
-	const MTLFormula  sink{AP{"sink"}};
+	// const std::string a_symbol{{a}};
+	// const std::string b_symbol{{b}};
+	// const std::string c_symbol{{c}};
+	// const MTLFormula  a{AP{{a}}};
+	// const MTLFormula  b{AP{{b}}};
+	const MTLFormula sink{AP{"sink"}};
 
 	SECTION("Sink location in the very first transition")
 	{
 		spdlog::set_level(spdlog::level::debug);
-		const MTLFormula phi = a && !a;
-		const auto       ata = translate(phi, {AP("a")});
+		const MTLFormula phi = MTLFormula{a} && !a;
+		const auto       ata = translate(phi, {AP(a)});
 		CAPTURE(ata);
 
 		// After reading a, phi is no longer satisfiable.
-		auto runs = ata.make_symbol_transition({{}}, a_symbol);
+		auto runs = ata.make_symbol_transition({{}}, a);
 		// Thus, we should end up in the sink location.
 		CAPTURE(runs);
 		REQUIRE(runs.size() == 1);
@@ -344,7 +349,7 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 		CHECK(runs[0][0].second == Configuration{{sink, 0}});
 
 		// We should be able to loop in the sink location.
-		runs = ata.make_symbol_transition(ata.make_time_transition(runs, 0), a_symbol);
+		runs = ata.make_symbol_transition(ata.make_time_transition(runs, 0), a);
 		CAPTURE(runs);
 		REQUIRE(runs.size() == 1);
 		REQUIRE(runs[0].size() == 3);
@@ -353,16 +358,16 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 
 	SECTION("Sink location for an until transition")
 	{
-		const MTLFormula phi = a.until(b);
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c")});
+		const MTLFormula phi = MTLFormula{a}.until(b);
+		const auto       ata = translate(phi, {a, b, c});
 		CAPTURE(ata);
 
 		// After reading a -> 0 -> c, phi is no longer satisfiable.
-		auto runs = ata.make_symbol_transition({{}}, a_symbol);
+		auto runs = ata.make_symbol_transition({{}}, a);
 		CAPTURE(runs);
 		runs = ata.make_time_transition(runs, 0);
 		CAPTURE(runs);
-		runs = ata.make_symbol_transition(runs, c_symbol);
+		runs = ata.make_symbol_transition(runs, c);
 		CAPTURE(runs);
 		REQUIRE(runs.size() == 1);
 		REQUIRE(runs[0].size() == 3);
@@ -372,13 +377,14 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 
 	SECTION("Sink location for a dual until transition")
 	{
-		const MTLFormula phi = a.dual_until(b);
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c")});
+		const MTLFormula phi = MTLFormula{a}.dual_until(b);
+		const auto       ata = translate(phi, {a, b, c});
 		CAPTURE(ata);
 
 		// After reading a -> 0 -> c, phi is no longer satisfiable.
-		auto runs = ata.make_symbol_transition(
-		  ata.make_time_transition(ata.make_symbol_transition({{}}, a_symbol), 0), c_symbol);
+		auto runs =
+		  ata.make_symbol_transition(ata.make_time_transition(ata.make_symbol_transition({{}}, a), 0),
+		                             c);
 		CAPTURE(runs);
 		REQUIRE(runs.size() == 1);
 		REQUIRE(runs[0].size() == 3);
@@ -388,13 +394,14 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 
 	SECTION("Sink location for an until transition with a duration")
 	{
-		const MTLFormula phi = a.until(b, TimeInterval{0, 1});
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c")});
+		const MTLFormula phi = MTLFormula{a}.until(b, TimeInterval{0, 1});
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c)});
 		CAPTURE(ata);
 
 		// After reading a -> 2 -> b, phi is no longer satisfiable.
-		auto runs = ata.make_symbol_transition(
-		  ata.make_time_transition(ata.make_symbol_transition({{}}, a_symbol), 2), b_symbol);
+		auto runs =
+		  ata.make_symbol_transition(ata.make_time_transition(ata.make_symbol_transition({{}}, a), 2),
+		                             b);
 		CAPTURE(runs);
 		REQUIRE(runs.size() == 1);
 		REQUIRE(runs[0].size() == 3);
@@ -404,13 +411,14 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 
 	SECTION("Sink location for a dual until transition with a duration")
 	{
-		const MTLFormula phi = a.dual_until(b, TimeInterval{0, 1});
-		const auto       ata = translate(phi, {AP("a"), AP("b"), AP("c")});
+		const MTLFormula phi = MTLFormula{a}.dual_until(b, TimeInterval{0, 1});
+		const auto       ata = translate(phi, {AP(a), AP(b), AP(c)});
 		CAPTURE(ata);
 
 		// After reading a -> 0 -> b, phi is no longer satisfiable.
-		auto runs = ata.make_symbol_transition(
-		  ata.make_time_transition(ata.make_symbol_transition({{}}, a_symbol), 0), a_symbol);
+		auto runs =
+		  ata.make_symbol_transition(ata.make_time_transition(ata.make_symbol_transition({{}}, a), 0),
+		                             a);
 		CAPTURE(runs);
 		REQUIRE(runs.size() == 1);
 		REQUIRE(runs[0].size() == 3);


### PR DESCRIPTION
To improve testing and allow ATAWords not defined over strings, introduce additional typedefs.