### PR TITLE
Allow MTL -> ATA translation for MTL constraints with set semantics

### DIFF
--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -35,6 +35,9 @@ operator<<(std::ostream &out, const logic::AtomicProposition<APType> &a)
 	if constexpr (std::is_same_v<APType, std::vector<std::string>>) {
 		fmt::print(out, "({})", fmt::join(a.ap_, ", "));
 		return out;
+	} else if constexpr (std::is_same_v<APType, std::set<std::string>>) {
+		fmt::print(out, "{{{}}}", fmt::join(a.ap_, ", "));
+		return out;
 	} else {
 		out << a.ap_;
 		return out;

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
@@ -33,11 +33,13 @@ namespace tacos::mtl_ata_translation {
  * @param alphabet The alphabet that the ATA should read, defaults to the symbols of the formula.
  * @return An ATA that accepts a word w iff the word is in the language of the formula.
  */
-template <typename ConstraintSymbolT>
+template <typename ConstraintSymbolT,
+          typename SymbolT = ConstraintSymbolT,
+          bool state_based = false>
 automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ConstraintSymbolT>,
-                                         logic::AtomicProposition<ConstraintSymbolT>>
-translate(const logic::MTLFormula<ConstraintSymbolT> &          input_formula,
-          std::set<logic::AtomicProposition<ConstraintSymbolT>> alphabet = {});
+                                         logic::AtomicProposition<SymbolT>>
+translate(const logic::MTLFormula<ConstraintSymbolT> &input_formula,
+          std::set<logic::AtomicProposition<SymbolT>> alphabet = {});
 
 } // namespace tacos::mtl_ata_translation
 

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -235,42 +235,20 @@ init(const MTLFormula<ConstraintSymbolT> &formula,
 	throw std::logic_error("Unexpected formula operator");
 }
 
-/** Get the initial location of the ATA for string-based constraints. */
-template <typename ConstraintSymbolT,
-          std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::string>, bool> = true>
+/** Get the initial location of the ATA. */
+template <typename ConstraintSymbolT>
 AtomicProposition<ConstraintSymbolT>
 get_l0()
 {
-	return AtomicProposition{ConstraintSymbolT{std::string{"l0"}}};
+	return AtomicProposition{ConstraintSymbolT{{"l0"}}};
 }
 
-/** Get the initial location of the ATA for set-based constraints. */
-template <
-  typename ConstraintSymbolT,
-  std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::set<std::string>>, bool> = true>
-AtomicProposition<ConstraintSymbolT>
-get_l0()
-{
-	return AtomicProposition{std::set{std::string{"l0"}}};
-}
-
-/** Get the sink location of the ATA for string-based constraints. */
-template <typename ConstraintSymbolT,
-          std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::string>, bool> = true>
+/** Get the sink location of the ATAs. */
+template <typename ConstraintSymbolT>
 AtomicProposition<ConstraintSymbolT>
 get_sink()
 {
-	return AtomicProposition{ConstraintSymbolT{std::string{"sink"}}};
-}
-
-/** Get the sink location of the ATA for set-based constraints. */
-template <
-  typename ConstraintSymbolT,
-  std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::set<std::string>>, bool> = true>
-AtomicProposition<ConstraintSymbolT>
-get_sink()
-{
-	return AtomicProposition{std::set{std::string{"sink"}}};
+	return AtomicProposition{ConstraintSymbolT{{"sink"}}};
 }
 
 template <bool state_based, typename ConstraintSymbolT>
@@ -314,19 +292,31 @@ translate(const MTLFormula<ConstraintSymbolT> &input_formula,
 		if (input_alphabet.empty()) {
 			input_alphabet = compute_alphabet<true>(formula.get_alphabet());
 		}
+		if (input_alphabet.count(AtomicProposition<SymbolT>{{get_l0<ConstraintSymbolT>().ap_}}) > 0) {
+			throw std::invalid_argument(
+			  fmt::format("The formula alphabet must not contain the symbol '{{{}}}'",
+			              get_l0<ConstraintSymbolT>()));
+		}
+		if (input_alphabet.count(AtomicProposition<SymbolT>{{get_sink<ConstraintSymbolT>().ap_}}) > 0) {
+			throw std::invalid_argument(
+			  fmt::format("The formula alphabet must not contain the symbol '{{{}}}'",
+			              get_sink<ConstraintSymbolT>()));
+		}
 	} else {
 		if (input_alphabet.empty()) {
 			// The ATA alphabet is the same as the formula alphabet.
 			input_alphabet = formula.get_alphabet();
 		}
-	}
-	if (input_alphabet.count(get_l0<SymbolT>()) > 0) {
-		throw std::invalid_argument(
-		  fmt::format("The formula alphabet must not contain the symbol '{}'", get_l0<SymbolT>()));
-	}
-	if (input_alphabet.count(get_sink<SymbolT>()) > 0) {
-		throw std::invalid_argument(
-		  fmt::format("The formula alphabet must not contain the symbol '{}'", get_l0<SymbolT>()));
+		if (input_alphabet.count(get_l0<ConstraintSymbolT>()) > 0) {
+			throw std::invalid_argument(
+			  fmt::format("The formula alphabet must not contain the symbol '{}'",
+			              get_l0<ConstraintSymbolT>()));
+		}
+		if (input_alphabet.count(get_sink<ConstraintSymbolT>()) > 0) {
+			throw std::invalid_argument(
+			  fmt::format("The formula alphabet must not contain the symbol '{}'",
+			              get_sink<ConstraintSymbolT>()));
+		}
 	}
 	const auto alphabet = input_alphabet;
 	// const auto alphabet = compute_alphabet<state_based, ConstraintSymbolT>(input_alphabet);

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -184,10 +184,10 @@ init(const MTLFormula<ConstraintSymbolT> &formula,
 	case LOP::AP:
 		if constexpr (state_based) {
 			if (ap.ap_.find(formula.get_atomicProposition().ap_) != ap.ap_.end()) {
-				// init(b, a) = TRUE if b == a
+				// init(b, a) = TRUE if b is contained in a
 				return std::make_unique<TrueFormula<ConstraintSymbolT>>();
 			} else {
-				// init(b, a) = FALSE if b != a
+				// init(b, a) = FALSE if b is not contained in a
 				return std::make_unique<FalseFormula<ConstraintSymbolT>>();
 			}
 		} else {
@@ -211,10 +211,10 @@ init(const MTLFormula<ConstraintSymbolT> &formula,
 			if constexpr (state_based) {
 				if (ap.ap_.find(formula.get_operands().front().get_atomicProposition().ap_)
 				    != ap.ap_.end()) {
-					// init(b, a) = TRUE if b == a
+					// init(b, a) = FALSE if b is contained in a
 					return std::make_unique<FalseFormula<ConstraintSymbolT>>();
 				} else {
-					// init(b, a) = FALSE if b != a
+					// init(b, a) = TRUE if b is not contained in a
 					return std::make_unique<TrueFormula<ConstraintSymbolT>>();
 				}
 			} else {

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -244,14 +244,14 @@ get_l0()
 	return AtomicProposition{ConstraintSymbolT{std::string{"l0"}}};
 }
 
-/** Get the initial location of the ATA for vector-based constraints. */
-template <typename ConstraintSymbolT,
-          std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::vector<std::string>>,
-                           bool> = true>
+/** Get the initial location of the ATA for set-based constraints. */
+template <
+  typename ConstraintSymbolT,
+  std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::set<std::string>>, bool> = true>
 AtomicProposition<ConstraintSymbolT>
 get_l0()
 {
-	return AtomicProposition{ConstraintSymbolT{std::vector{std::string{"l0"}}}};
+	return AtomicProposition{std::set{std::string{"l0"}}};
 }
 
 /** Get the sink location of the ATA for string-based constraints. */
@@ -263,14 +263,14 @@ get_sink()
 	return AtomicProposition{ConstraintSymbolT{std::string{"sink"}}};
 }
 
-/** Get the sink location of the ATA for vector-based constraints. */
-template <typename ConstraintSymbolT,
-          std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::vector<std::string>>,
-                           bool> = true>
+/** Get the sink location of the ATA for set-based constraints. */
+template <
+  typename ConstraintSymbolT,
+  std::enable_if_t<std::is_constructible_v<ConstraintSymbolT, std::set<std::string>>, bool> = true>
 AtomicProposition<ConstraintSymbolT>
 get_sink()
 {
-	return AtomicProposition{ConstraintSymbolT{std::vector{std::string{"sink"}}}};
+	return AtomicProposition{std::set{std::string{"sink"}}};
 }
 
 template <bool state_based, typename ConstraintSymbolT>
@@ -319,16 +319,14 @@ translate(const MTLFormula<ConstraintSymbolT> &input_formula,
 			// The ATA alphabet is the same as the formula alphabet.
 			input_alphabet = formula.get_alphabet();
 		}
-		if (input_alphabet.count(get_l0<ConstraintSymbolT>()) > 0) {
-			throw std::invalid_argument(
-			  fmt::format("The formula alphabet must not contain the symbol '{}'",
-			              get_l0<ConstraintSymbolT>()));
-		}
-		if (input_alphabet.count(get_sink<ConstraintSymbolT>()) > 0) {
-			throw std::invalid_argument(
-			  fmt::format("The formula alphabet must not contain the symbol '{}'",
-			              get_sink<ConstraintSymbolT>()));
-		}
+	}
+	if (input_alphabet.count(get_l0<SymbolT>()) > 0) {
+		throw std::invalid_argument(
+		  fmt::format("The formula alphabet must not contain the symbol '{}'", get_l0<SymbolT>()));
+	}
+	if (input_alphabet.count(get_sink<SymbolT>()) > 0) {
+		throw std::invalid_argument(
+		  fmt::format("The formula alphabet must not contain the symbol '{}'", get_l0<SymbolT>()));
 	}
 	const auto alphabet = input_alphabet;
 	// const auto alphabet = compute_alphabet<state_based, ConstraintSymbolT>(input_alphabet);

--- a/src/utilities/include/utilities/powerset.h
+++ b/src/utilities/include/utilities/powerset.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+ *  powerset.h - power set construction
+ *
+ *  Created:   Wed 19 Jan 14:43:59 CET 2022
+ *  Copyright  2022  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include <set>
+
+namespace tacos::utilities {
+
+template <typename Element>
+std::set<std::set<Element>>
+construct_powerset(const std::set<Element> &input)
+{
+	std::set<std::set<Element>> powerset = {{}};
+	for (const auto &symbol : input) {
+		auto new_elements = powerset;
+		for (const auto &partial_set : powerset) {
+			auto new_element = partial_set;
+			new_element.insert(symbol);
+			new_elements.insert(new_element);
+		}
+		powerset.merge(new_elements);
+	}
+	return powerset;
+}
+
+} // namespace tacos::utilities

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,10 @@ add_executable(testnumberutilities test_number_utilities.cpp)
 target_link_libraries(testnumberutilities PRIVATE utilities PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(testnumberutilities)
 
+add_executable(test_powerset test_powerset.cpp)
+target_link_libraries(test_powerset PRIVATE utilities Catch2::Catch2WithMain)
+catch_discover_tests(test_powerset)
+
 add_executable(testmtlformulae test_mtlFormula.cpp test_print_mtl_formula.cpp)
 target_link_libraries(testmtlformulae PRIVATE mtl PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(testmtlformulae)

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -317,8 +317,8 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 
 TEST_CASE("MTL ATA Translation exceptions", "[translator][exceptions]")
 {
-	// CHECK_THROWS_AS(translate(MTLFormula{AP{"l0"}}), std::invalid_argument);
-	// CHECK_THROWS_AS(translate(MTLFormula{AP{"sink"}}), std::invalid_argument);
+	CHECK_THROWS_AS(translate(MTLFormula{AP{"l0"}}), std::invalid_argument);
+	CHECK_THROWS_AS(translate(MTLFormula{AP{"sink"}}), std::invalid_argument);
 }
 
 TEST_CASE("MTL ATA sink location", "[translator][sink]")
@@ -486,6 +486,18 @@ TEST_CASE("State-based MTL ATA Translation", "[translator]")
 		CHECK(mtl_ata_translation::compute_alphabet<true, std::string>({a, b})
 		      == std::set{APSet{{}}, APSet{{"a"}}, APSet{{"b"}}, APSet{{"a", "b"}}});
 		CHECK(ata.get_alphabet() == mtl_ata_translation::compute_alphabet<true, std::string>({a, b}));
+	}
+	SECTION("Invalid sink symbol in the formula")
+	{
+		const MTLFormula phi = sink.until(b);
+		CAPTURE(phi.get_alphabet());
+		CHECK_THROWS(translate<std::string, std::set<std::string>, true>(phi));
+	}
+	SECTION("Invalid l0 symbol in the formula")
+	{
+		const MTLFormula phi = l0.until(b);
+		CAPTURE(phi.get_alphabet());
+		CHECK_THROWS(translate<std::string, std::set<std::string>, true>(phi));
 	}
 }
 

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -317,8 +317,8 @@ TEST_CASE("ATA satisfiability of simple MTL formulas", "[translator]")
 
 TEST_CASE("MTL ATA Translation exceptions", "[translator][exceptions]")
 {
-	CHECK_THROWS_AS(translate(MTLFormula{AP{"l0"}}), std::invalid_argument);
-	CHECK_THROWS_AS(translate(MTLFormula{AP{"sink"}}), std::invalid_argument);
+	// CHECK_THROWS_AS(translate(MTLFormula{AP{"l0"}}), std::invalid_argument);
+	// CHECK_THROWS_AS(translate(MTLFormula{AP{"sink"}}), std::invalid_argument);
 }
 
 TEST_CASE("MTL ATA sink location", "[translator][sink]")
@@ -425,6 +425,25 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 		// Thus, we should end up in the sink location.
 		CHECK(runs[0][2].second == Configuration{{sink, 0}});
 	}
+}
+
+TEST_CASE("State-based MTL ATA Translation", "[translator]")
+{
+	using APSet = logic::AtomicProposition<std::set<std::string>>;
+	const APSet      symbol_e{std::set<std::string>{}};
+	const APSet      symbol_a{std::set<std::string>{"a"}};
+	const APSet      symbol_ab{std::set<std::string>{"a", "b"}};
+	const APSet      symbol_b{std::set<std::string>{"b"}};
+	const MTLFormula phi      = MTLFormula{a}.until(b, TimeInterval(0, 1));
+	const auto       alphabet = mtl_ata_translation::compute_alphabet<true, std::string>({a, b, c});
+	const auto       ata      = translate<std::string, std::set<std::string>, true>(phi, alphabet);
+	CAPTURE(ata);
+	CHECK(ata.accepts_word({{symbol_a, 0}, {symbol_ab, 0.5}}));
+	CHECK(ata.accepts_word({{symbol_a, 0}, {symbol_ab, 0.5}, {symbol_ab, 1.0}}));
+	CHECK(ata.accepts_word({{symbol_a, 0}, {symbol_b, 0.5}, {symbol_ab, 1.0}}));
+	CHECK(!ata.accepts_word({{symbol_a, 0}, {symbol_b, 1.5}, {symbol_ab, 2.0}}));
+	CHECK(!ata.accepts_word({{symbol_a, 0}, {symbol_e, 0.5}, {symbol_ab, 0.8}}));
+	CHECK(!ata.accepts_word({{symbol_a, 0}, {symbol_a, 0.5}, {symbol_a, 1.0}}));
 }
 
 } // namespace

--- a/test/test_powerset.cpp
+++ b/test/test_powerset.cpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *  test_powerset.cpp - Test powerset generation
+ *
+ *  Created:   Wed 19 Jan 14:49:40 CET 2022
+ *  Copyright  2022  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.md file.
+ */
+
+#include "utilities/powerset.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+#include <string>
+
+using tacos::utilities::construct_powerset;
+
+TEST_CASE("Power set", "[utilities]")
+{
+	std::set<std::string> input{"a", "b"};
+	CHECK(construct_powerset(input) == std::set<std::set<std::string>>{{}, {"a"}, {"b"}, {"a", "b"}});
+	CHECK(construct_powerset(std::set<std::string>{}) == std::set<std::set<std::string>>{{}});
+}


### PR DESCRIPTION
Instead of defining a timed word as a sequence over single symbols (and timesteps), we may also want to have a set of symbols at each step. This is particularly useful when using location constraints, as locations are typically labeled with sets of properties that we may compare against.

To create the ATA, we simply construct the powerset of all symbols that occur in the input MTL formula.