### PR TITLE
Pin the version of catch2

### DIFF
--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -67,7 +67,7 @@ else()
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG devel
+    GIT_TAG v3.0.0-preview4
     GIT_SHALLOW TRUE
   )
   FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
Pin the version so upstream updates do not break our build.

This was not possibly previously, as the available pre-release was too old.