### PR TITLE
Pin the version of catch2

### DIFF
--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -60,7 +60,7 @@ else()
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG devel
+    GIT_TAG v3.0.0-preview4
     GIT_SHALLOW TRUE)
   FetchContent_MakeAvailable(Catch2)
   target_compile_options(Catch2 PRIVATE "-DCATCH_CONFIG_CONSOLE_WIDTH=200")


### PR DESCRIPTION
Pin the version so upstream updates do not break our build.

This was not possibly previously, as the available pre-release was too old.

This is the same PR as #132, but against `main` instead of `1.x`.