### PR TITLE
search: do not merge successors with different actions based on reg_a 

### DIFF
--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -286,9 +286,9 @@ public:
 		             node->get_children().size(),
 		             new_children.size());
 		if (node->get_children().empty()) {
-			node->state = NodeState::DEAD;
+			node->label_reason = LabelReason::DEAD_NODE;
+			node->state        = NodeState::DEAD;
 			if (incremental_labeling_) {
-				node->label_reason = LabelReason::DEAD_NODE;
 				node->set_label(NodeLabel::TOP, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
 			}
@@ -367,13 +367,10 @@ private:
 		assert(node->get_children().empty());
 		// Represent a set of configurations by their reg_a component so we can later partition the
 		// set
-		std::map<CanonicalABWord<Location, ConstraintSymbolType>,
-		         std::set<CanonicalABWord<Location, ConstraintSymbolType>>>
+		std::map<std::pair<RegionIndex, ActionType>,
+		         std::map<CanonicalABWord<Location, ConstraintSymbolType>,
+		                  std::set<CanonicalABWord<Location, ConstraintSymbolType>>>>
 		  child_classes;
-		// Store with which actions we reach each CanonicalABWord
-		std::map<CanonicalABWord<Location, ConstraintSymbolType>,
-		         std::set<std::pair<RegionIndex, ActionType>>>
-		  outgoing_actions;
 
 		// Pre-compute time successors so we avoid re-computing them for each symbol.
 		std::map<CanonicalABWord<Location, ConstraintSymbolType>,
@@ -399,12 +396,10 @@ private:
 			// Partition the successors by their reg_a component.
 			for (const auto &[increment, successor] : successors) {
 				const auto word_reg = reg_a(successor);
-				child_classes[word_reg].insert(successor);
-				outgoing_actions[word_reg].insert(std::make_pair(increment, symbol));
+				child_classes[std::make_pair(increment, symbol)][word_reg].insert(successor);
+				// outgoing_actions[word_reg].insert(std::make_pair(increment, symbol));
 			}
 		}
-
-		assert(child_classes.size() == outgoing_actions.size());
 
 		std::set<Node *> new_children;
 		std::set<Node *> existing_children;
@@ -412,12 +407,11 @@ private:
 		// the same reg_a class.
 		{
 			std::lock_guard lock{nodes_mutex_};
-			std::for_each(std::begin(child_classes), std::end(child_classes), [&](const auto &map_entry) {
-				const auto &[reg_a, words] = map_entry;
-				auto [child_it, is_new]    = nodes_.insert({words, std::make_shared<Node>(words)});
-				const std::shared_ptr<Node> &child_ptr = child_it->second;
-				for (const auto &action : outgoing_actions[reg_a]) {
-					node->add_child(action, child_ptr);
+			for (const auto &[timed_action, word_map] : child_classes) {
+				for (const auto &[reg_a, words] : word_map) {
+					auto [child_it, is_new] = nodes_.insert({words, std::make_shared<Node>(words)});
+					const std::shared_ptr<Node> &child_ptr = child_it->second;
+					node->add_child(timed_action, child_ptr);
 					if (is_new) {
 						SPDLOG_TRACE("New child: {}", words);
 						new_children.insert(child_ptr.get());
@@ -425,7 +419,7 @@ private:
 						existing_children.insert(child_ptr.get());
 					}
 				}
-			});
+			}
 		}
 		return {new_children, existing_children};
 	}


### PR DESCRIPTION
This fixes a bug in the following situation: If two actions generate the
same plant successor, but with different ATA successors, then the two
successors were merged into a single successor node. However, this is
wrong, as we now can no longer distinguish which action has occurred.
Instead, we should only merge canonical words with the same reg_a if
they can be reached with the same (timed) action. If we reach a
canonical word with the same reg_a but a different action, then this
must go into a separate node.

Note that if the two successors are identical (i.e., same plant and ATA
configuration), then they will be merged regardless, as we re-use a node
if it is completely the same. This is however different to the scenario
described above, where we only compared based on reg_a. Here, we also
include the ATA configuration for comparison.

This is the same PR as #131 but rebased onto `release/1.x`.