### PR TITLE
Exclude self loops in monotonic domination checks

### DIFF
--- a/src/search/include/search/operators.h
+++ b/src/search/include/search/operators.h
@@ -122,7 +122,7 @@ template <typename LocationT, typename ActionT, typename ConstraintSymbolT>
 bool
 dominates_ancestor(SearchTreeNode<LocationT, ActionT, ConstraintSymbolT> *node)
 {
-	std::vector<const SearchTreeNode<LocationT, ActionT, ConstraintSymbolT> *> seen_nodes;
+	std::vector<const SearchTreeNode<LocationT, ActionT, ConstraintSymbolT> *> seen_nodes = {node};
 	return std::any_of(node->parents.begin(),
 	                   node->parents.end(),
 	                   [node, &seen_nodes](const auto &parent) {

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -286,19 +286,6 @@ public:
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
 			}
 		}
-		if (!existing_children.empty() && dominates_ancestor(node)) {
-			// If we have a loop, this node may be dominating itself, but we can find that out only
-			// after adding an existing child. Therefore, check again for monotonic domination.
-			node->label_reason = LabelReason::MONOTONIC_DOMINATION;
-			node->state        = NodeState::GOOD;
-			node->is_expanded  = true;
-			node->is_expanding = false;
-			if (incremental_labeling_) {
-				node->set_label(NodeLabel::TOP, terminate_early_);
-				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
-			}
-			return;
-		}
 	}
 
 	/** Compute the final tree labels.

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -314,9 +314,14 @@ public:
 		if (node->label != NodeLabel::UNLABELED) {
 			return;
 		}
-		if (node->state == NodeState::GOOD || node->state == NodeState::DEAD) {
+		if (node->state == NodeState::GOOD) {
+			node->label_reason = LabelReason::GOOD_NODE;
+			node->set_label(NodeLabel::TOP, terminate_early_);
+		} else if (node->state == NodeState::DEAD) {
+			node->label_reason = LabelReason::DEAD_NODE;
 			node->set_label(NodeLabel::TOP, terminate_early_);
 		} else if (node->state == NodeState::BAD) {
+			node->label_reason = LabelReason::BAD_NODE;
 			node->set_label(NodeLabel::BOTTOM, terminate_early_);
 		} else {
 			for (const auto &[action, child] : node->get_children()) {
@@ -338,9 +343,14 @@ public:
 					first_bad_environment_step = std::min(first_bad_environment_step, step);
 				}
 			}
-			if (!found_bad || first_good_controller_step < first_bad_environment_step) {
+			if (!found_bad) {
+				node->label_reason = LabelReason::NO_BAD_ENV_ACTION;
+				node->set_label(NodeLabel::TOP, terminate_early_);
+			} else if (first_good_controller_step < first_bad_environment_step) {
+				node->label_reason = LabelReason::GOOD_CONTROLLER_ACTION_FIRST;
 				node->set_label(NodeLabel::TOP, terminate_early_);
 			} else {
+				node->label_reason = LabelReason::BAD_ENV_ACTION_FIRST;
 				node->set_label(NodeLabel::BOTTOM, terminate_early_);
 			}
 		}

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -211,6 +211,7 @@ public:
 		}
 		SPDLOG_TRACE("Processing {}", *node);
 		if (is_bad_node(node)) {
+			SPDLOG_DEBUG("Node {} is BAD", *node);
 			node->label_reason = LabelReason::BAD_NODE;
 			node->state        = NodeState::BAD;
 			node->is_expanded  = true;
@@ -256,19 +257,6 @@ public:
 			// The node has been canceled in the meantime, do not add children to queue.
 			return;
 		}
-		if (!existing_children.empty() && dominates_ancestor(node)) {
-			// If we have a loop, this node may be dominating itself, but we can find that out only
-			// after adding an existing child. Therefore, check again for monotonic domination.
-			node->label_reason = LabelReason::MONOTONIC_DOMINATION;
-			node->state        = NodeState::GOOD;
-			node->is_expanded  = true;
-			node->is_expanding = false;
-			if (incremental_labeling_) {
-				node->set_label(NodeLabel::TOP, terminate_early_);
-				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
-			}
-			return;
-		}
 		for (const auto &child : existing_children) {
 			SPDLOG_TRACE("Found existing node for {}", fmt::ptr(child));
 			if (child->label == NodeLabel::CANCELED) {
@@ -297,6 +285,19 @@ public:
 				node->set_label(NodeLabel::TOP, terminate_early_);
 				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
 			}
+		}
+		if (!existing_children.empty() && dominates_ancestor(node)) {
+			// If we have a loop, this node may be dominating itself, but we can find that out only
+			// after adding an existing child. Therefore, check again for monotonic domination.
+			node->label_reason = LabelReason::MONOTONIC_DOMINATION;
+			node->state        = NodeState::GOOD;
+			node->is_expanded  = true;
+			node->is_expanding = false;
+			if (incremental_labeling_) {
+				node->set_label(NodeLabel::TOP, terminate_early_);
+				node->label_propagate(controller_actions_, environment_actions_, terminate_early_);
+			}
+			return;
 		}
 	}
 

--- a/src/search/search_tree.cpp
+++ b/src/search/search_tree.cpp
@@ -19,6 +19,8 @@
 
 #include "search/search_tree.h"
 
+#include <string_view>
+
 namespace tacos::search {
 std::ostream &
 operator<<(std::ostream &os, const search::NodeState &node_state)
@@ -43,6 +45,28 @@ operator<<(std::ostream &os, const search::NodeLabel &node_label)
 	case NodeLabel::UNLABELED: os << u8"?"; break;
 	case NodeLabel::CANCELED: os << "CANCELED"; break;
 	}
+	return os;
+}
+
+std::ostream &
+operator<<(std::ostream &os, const search::LabelReason &reason)
+{
+	std::string_view label_reason;
+	using tacos::search::LabelReason;
+	switch (reason) {
+	case LabelReason::UNKNOWN: label_reason = "unknown"; break;
+	case LabelReason::GOOD_NODE: label_reason = "good node"; break;
+	case LabelReason::BAD_NODE: label_reason = "bad node"; break;
+	case LabelReason::DEAD_NODE: label_reason = "dead node"; break;
+	case LabelReason::NO_ATA_SUCCESSOR: label_reason = "no ATA successor"; break;
+	case LabelReason::MONOTONIC_DOMINATION: label_reason = "monotonic domination"; break;
+	case LabelReason::NO_BAD_ENV_ACTION: label_reason = "no bad env action"; break;
+	case LabelReason::GOOD_CONTROLLER_ACTION_FIRST:
+		label_reason = "good controller action first";
+		break;
+	case LabelReason::BAD_ENV_ACTION_FIRST: label_reason = "bad env action first"; break;
+	}
+	os << label_reason;
 	return os;
 }
 

--- a/src/visualization/include/visualization/tree_to_graphviz.h
+++ b/src/visualization/include/visualization/tree_to_graphviz.h
@@ -64,6 +64,7 @@ add_search_node_to_graph(
 	std::string label_reason;
 	switch (search_node->label_reason) {
 	case LabelReason::UNKNOWN: label_reason = "unknown"; break;
+	case LabelReason::GOOD_NODE: label_reason = "good node"; break;
 	case LabelReason::BAD_NODE: label_reason = "bad node"; break;
 	case LabelReason::DEAD_NODE: label_reason = "dead node"; break;
 	case LabelReason::NO_ATA_SUCCESSOR: label_reason = "no ATA successor"; break;

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -289,8 +289,11 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->get_children().at({3, "a"})->state == NodeState::UNKNOWN);
 		CHECK(search.get_root()->get_children().at({0, "b"})->state == NodeState::DEAD);
 		CHECK(search.get_root()->get_children().at({1, "b"})->state == NodeState::DEAD);
+		// The node has children, therefore its state should be UNKNOWN.
+		// Note that even though it has a self-loop, it is not monotonically dominating, as we exclude
+		// self loops in the monotonic domination check.
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({3, "a"})->state
-		      == NodeState::GOOD);
+		      == NodeState::UNKNOWN);
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({0, "b"})->state
 		      == NodeState::GOOD);
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({1, "b"})->state
@@ -300,8 +303,9 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->get_children().at({3, "a"})->label == NodeLabel::BOTTOM);
 		CHECK(search.get_root()->get_children().at({0, "b"})->label == NodeLabel::TOP);
 		CHECK(search.get_root()->get_children().at({1, "b"})->label == NodeLabel::TOP);
+		// The node only has bad children.
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({3, "a"})->label
-		      == NodeLabel::TOP);
+		      == NodeLabel::BOTTOM);
 		// (3, a) -> (0, b) should be labeled with top, as it the constraint a U>=2 b can no longer be
 		// satisfied.
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({0, "b"})->label

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -169,26 +169,29 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 
 	SECTION("The next steps compute the right children")
 	{
+		unsigned int step_count = 0;
 		REQUIRE(search.step());
 		visualization::search_tree_to_graphviz(*search.get_root(), false)
-		  .render_to_file("search_step2.png");
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		REQUIRE(search.step());
 		visualization::search_tree_to_graphviz(*search.get_root(), false)
-		  .render_to_file("search_step3.png");
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		REQUIRE(search.step());
 		visualization::search_tree_to_graphviz(*search.get_root(), false)
-		  .render_to_file("search_step4.png");
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		REQUIRE(search.step());
 		visualization::search_tree_to_graphviz(*search.get_root(), false)
-		  .render_to_file("search_step5.png");
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		REQUIRE(search.step());
 		visualization::search_tree_to_graphviz(*search.get_root(), false)
-		  .render_to_file("search_step6.png");
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		const auto &root_children = search.get_root()->get_children();
 		REQUIRE(root_children.size() == 5);
 
 		// Process (0, b) child of the root.
 		REQUIRE(search.step());
+		visualization::search_tree_to_graphviz(*search.get_root(), false)
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		INFO("Tree:\n" << *search.get_root());
 		CHECK(
 		  root_children.at({0, "b"})->get_children().empty()); // should be ({(l1, x, 0), ((a U b), 0)})
@@ -197,6 +200,8 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 
 		// Process (1, b) child of the root.
 		REQUIRE(search.step());
+		visualization::search_tree_to_graphviz(*search.get_root(), false)
+		  .render_to_file(fmt::format("search_step{}.png", ++step_count));
 		INFO("Tree:\n" << *search.get_root());
 		REQUIRE(
 		  root_children.at({1, "b"})->get_children().empty()); // should be ({(l1, x, 1), ((a U b), 1)})


### PR DESCRIPTION
While techically, a node always monotonically dominates itself, we must exclude self loops from the check, as treating self loops as monotonically dominating is dangerous: The initial assumption of monotonic domination is that if we could reach a
bad configuration from the current node, then we can also reach that configuration from the dominated ancestor, thus we can stop expanding the current node. However, if the ancestor is actually the same node, then we must not stop expansion, as this means  that we check neither node. Therefore, we must exclude self loops in the monotonic domination check.

Consider the following example (from [this test case](https://github.com/morxa/tacos/blob/cb90f481925e0c72c1e6a2d39d0a0a54ef1d9d21/test/test_search.cpp#L251)):
![search_final_bad](https://user-images.githubusercontent.com/4573064/157846516-5963a738-09b6-44dd-842d-5a7844a2f57f.png)
The node in the middle is monotonically dominating itself and therefore marked as GOOD. However, clearly, the node is not good, because all its children are BAD. Instead, with this PR, the new result looks as follows:
![search_final](https://user-images.githubusercontent.com/4573064/157846808-02e49dc8-293d-40bc-a8b0-cf37e4e801aa.png)

This issue was found due to a slightly different bug, where, depending on the order of node expansion, the children of the monotonically dominating node were created but not expanded. If such a node is also a child of a different node, it would still not be expanded, as the node already exists and therefore is assumed to be in the queue already (which was not the case here). This bug is fixed by removing the second domination check (which occurred after the children were created).

Note that this PR also includes the first fix for this bug (ddd0427bc81c0a82259a04cd9a7cbddaf5960603), which is then removed again in cb90f481925e0c72c1e6a2d39d0a0a54ef1d9d21, but may still be useful to keep the history intact.
