### PR TITLE
utilities: correctly print strict and weak interval bounds

### DIFF
--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -149,9 +149,9 @@ public:
 	operator<<(std::ostream &os, const Interval &interval)
 	{
 		switch (interval.lowerBoundType_) {
-		case BoundType::WEAK:
+		case BoundType::STRICT:
 		case BoundType::INFTY: os << "("; break;
-		case BoundType::STRICT: os << "["; break;
+		case BoundType::WEAK: os << "["; break;
 		}
 		if (interval.lowerBoundType_ == BoundType::INFTY) {
 			os << u8"∞";
@@ -165,9 +165,9 @@ public:
 			os << interval.upper_;
 		}
 		switch (interval.upperBoundType_) {
-		case BoundType::WEAK:
+		case BoundType::STRICT:
 		case BoundType::INFTY: os << ")"; break;
-		case BoundType::STRICT: os << "]"; break;
+		case BoundType::WEAK: os << "]"; break;
 		}
 		return os;
 	}

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -170,27 +170,27 @@ TEST_CASE("Print an interval", "[libmtl][print]")
 	SECTION("weak lower bound")
 	{
 		str << Interval(1, BoundType::WEAK, 0, BoundType::INFTY);
-		CHECK(str.str() == u8"(1, ∞)");
+		CHECK(str.str() == u8"[1, ∞)");
 	}
 	SECTION("strict lower bound")
 	{
 		str << Interval(2, BoundType::STRICT, 0, BoundType::INFTY);
-		CHECK(str.str() == u8"[2, ∞)");
+		CHECK(str.str() == u8"(2, ∞)");
 	}
 	SECTION("weak upper bound")
 	{
 		str << Interval(0, BoundType::INFTY, 1, BoundType::WEAK);
-		CHECK(str.str() == u8"(∞, 1)");
+		CHECK(str.str() == u8"(∞, 1]");
 	}
 	SECTION("strict upper bound")
 	{
 		str << Interval(0, BoundType::INFTY, 1, BoundType::STRICT);
-		CHECK(str.str() == u8"(∞, 1]");
+		CHECK(str.str() == u8"(∞, 1)");
 	}
 	SECTION("weak lower and strict upper bound")
 	{
 		str << Interval(4, BoundType::WEAK, 5, BoundType::STRICT);
-		CHECK(str.str() == "(4, 5]");
+		CHECK(str.str() == "[4, 5)");
 	}
 }
 } // namespace

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "mtl/MTLFormula.h"
+#include "utilities/Interval.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <sstream>
@@ -27,6 +28,7 @@ namespace {
 using namespace tacos;
 
 using logic::TimeInterval;
+using utilities::arithmetic::BoundType;
 
 TEST_CASE("Print MTL formulas", "[print][mtl]")
 {
@@ -91,7 +93,13 @@ TEST_CASE("Print MTL formulas", "[print][mtl]")
 	SECTION("until with time bounds")
 	{
 		s << (Formula(AP{"a"}).until(Formula{AP{"b"}}, TimeInterval(1, 2)));
-		CHECK(s.str() == "(a U(1, 2) b)");
+		CHECK(s.str() == "(a U[1, 2] b)");
+	}
+	SECTION("until with strict time bound")
+	{
+		s << (Formula(AP{"a"}).until(Formula{AP{"b"}},
+		                             TimeInterval(1, BoundType::STRICT, 3, BoundType::WEAK)));
+		CHECK(s.str() == "(a U(1, 3] b)");
 	}
 	SECTION("dual until")
 	{
@@ -101,7 +109,13 @@ TEST_CASE("Print MTL formulas", "[print][mtl]")
 	SECTION("dual until with time bounds")
 	{
 		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}}, TimeInterval(1, 2)));
-		CHECK(s.str() == "(a ~U(1, 2) b)");
+		CHECK(s.str() == "(a ~U[1, 2] b)");
+	}
+	SECTION("dual until with strict time bound")
+	{
+		s << (Formula(AP{"a"}).dual_until(Formula{AP{"b"}},
+		                                  TimeInterval(3, BoundType::WEAK, 5, BoundType::STRICT)));
+		CHECK(s.str() == "(a ~U[3, 5) b)");
 	}
 }
 


### PR DESCRIPTION
We should use "()" for strict and "[]" for weak interval bounds, not the
other way around.