### PR TITLE
Avoid infinite recursion in label function

### DIFF
--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -69,15 +69,22 @@ has_satisfiable_ata_configuration(
 	});
 }
 
+namespace details {
+
 template <typename Location, typename ActionType, typename ConstraintSymbolType>
 void
 label_graph(SearchTreeNode<Location, ActionType, ConstraintSymbolType> *node,
             const std::set<ActionType> &                                controller_actions,
-            const std::set<ActionType> &                                environment_actions)
+            const std::set<ActionType> &                                environment_actions,
+            std::set<SearchTreeNode<Location, ActionType, ConstraintSymbolType> *> *visited)
 {
 	if (node->label != NodeLabel::UNLABELED) {
 		return;
 	}
+	if (std::find(std::begin(*visited), std::end(*visited), node) != std::end(*visited)) {
+		return;
+	}
+	visited->insert(node);
 	if (node->state == NodeState::GOOD) {
 		node->label_reason = LabelReason::GOOD_NODE;
 		node->set_label(NodeLabel::TOP);
@@ -90,7 +97,7 @@ label_graph(SearchTreeNode<Location, ActionType, ConstraintSymbolType> *node,
 	} else {
 		for (const auto &[action, child] : node->get_children()) {
 			if (child.get() != node) {
-				label_graph(child.get(), controller_actions, environment_actions);
+				label_graph(child.get(), controller_actions, environment_actions, visited);
 			}
 		}
 		bool        found_bad = false;
@@ -118,6 +125,17 @@ label_graph(SearchTreeNode<Location, ActionType, ConstraintSymbolType> *node,
 			node->set_label(NodeLabel::BOTTOM);
 		}
 	}
+}
+} // namespace details
+
+template <typename Location, typename ActionType, typename ConstraintSymbolType>
+void
+label_graph(SearchTreeNode<Location, ActionType, ConstraintSymbolType> *node,
+            const std::set<ActionType> &                                controller_actions,
+            const std::set<ActionType> &                                environment_actions)
+{
+	std::set<SearchTreeNode<Location, ActionType, ConstraintSymbolType> *> visited;
+	return details::label_graph(node, controller_actions, environment_actions, &visited);
 }
 
 /** Search the configuration tree for a valid controller. */

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -69,6 +69,57 @@ has_satisfiable_ata_configuration(
 	});
 }
 
+template <typename Location, typename ActionType, typename ConstraintSymbolType>
+void
+label_graph(SearchTreeNode<Location, ActionType, ConstraintSymbolType> *node,
+            const std::set<ActionType> &                                controller_actions,
+            const std::set<ActionType> &                                environment_actions)
+{
+	if (node->label != NodeLabel::UNLABELED) {
+		return;
+	}
+	if (node->state == NodeState::GOOD) {
+		node->label_reason = LabelReason::GOOD_NODE;
+		node->set_label(NodeLabel::TOP);
+	} else if (node->state == NodeState::DEAD) {
+		node->label_reason = LabelReason::DEAD_NODE;
+		node->set_label(NodeLabel::TOP);
+	} else if (node->state == NodeState::BAD) {
+		node->label_reason = LabelReason::BAD_NODE;
+		node->set_label(NodeLabel::BOTTOM);
+	} else {
+		for (const auto &[action, child] : node->get_children()) {
+			if (child.get() != node) {
+				label_graph(child.get(), controller_actions, environment_actions);
+			}
+		}
+		bool        found_bad = false;
+		RegionIndex first_good_controller_step{std::numeric_limits<RegionIndex>::max()};
+		RegionIndex first_bad_environment_step{std::numeric_limits<RegionIndex>::max()};
+		for (const auto &[timed_action, child] : node->get_children()) {
+			const auto &[step, action] = timed_action;
+			if (child->label == NodeLabel::TOP
+			    && controller_actions.find(action) != std::end(controller_actions)) {
+				first_good_controller_step = std::min(first_good_controller_step, step);
+			} else if (child->label == NodeLabel::BOTTOM
+			           && environment_actions.find(action) != std::end(environment_actions)) {
+				found_bad                  = true;
+				first_bad_environment_step = std::min(first_bad_environment_step, step);
+			}
+		}
+		if (!found_bad) {
+			node->label_reason = LabelReason::NO_BAD_ENV_ACTION;
+			node->set_label(NodeLabel::TOP);
+		} else if (first_good_controller_step < first_bad_environment_step) {
+			node->label_reason = LabelReason::GOOD_CONTROLLER_ACTION_FIRST;
+			node->set_label(NodeLabel::TOP);
+		} else {
+			node->label_reason = LabelReason::BAD_ENV_ACTION_FIRST;
+			node->set_label(NodeLabel::BOTTOM);
+		}
+	}
+}
+
 /** Search the configuration tree for a valid controller. */
 template <typename Location,
           typename ActionType,
@@ -289,53 +340,10 @@ public:
 	void
 	label(Node *node = nullptr)
 	{
-		// TODO test the label function separately.
 		if (node == nullptr) {
 			node = get_root();
 		}
-		if (node->label != NodeLabel::UNLABELED) {
-			return;
-		}
-		if (node->state == NodeState::GOOD) {
-			node->label_reason = LabelReason::GOOD_NODE;
-			node->set_label(NodeLabel::TOP, terminate_early_);
-		} else if (node->state == NodeState::DEAD) {
-			node->label_reason = LabelReason::DEAD_NODE;
-			node->set_label(NodeLabel::TOP, terminate_early_);
-		} else if (node->state == NodeState::BAD) {
-			node->label_reason = LabelReason::BAD_NODE;
-			node->set_label(NodeLabel::BOTTOM, terminate_early_);
-		} else {
-			for (const auto &[action, child] : node->get_children()) {
-				if (child.get() != node) {
-					label(child.get());
-				}
-			}
-			bool        found_bad = false;
-			RegionIndex first_good_controller_step{std::numeric_limits<RegionIndex>::max()};
-			RegionIndex first_bad_environment_step{std::numeric_limits<RegionIndex>::max()};
-			for (const auto &[timed_action, child] : node->get_children()) {
-				const auto &[step, action] = timed_action;
-				if (child->label == NodeLabel::TOP
-				    && controller_actions_.find(action) != std::end(controller_actions_)) {
-					first_good_controller_step = std::min(first_good_controller_step, step);
-				} else if (child->label == NodeLabel::BOTTOM
-				           && environment_actions_.find(action) != std::end(environment_actions_)) {
-					found_bad                  = true;
-					first_bad_environment_step = std::min(first_bad_environment_step, step);
-				}
-			}
-			if (!found_bad) {
-				node->label_reason = LabelReason::NO_BAD_ENV_ACTION;
-				node->set_label(NodeLabel::TOP, terminate_early_);
-			} else if (first_good_controller_step < first_bad_environment_step) {
-				node->label_reason = LabelReason::GOOD_CONTROLLER_ACTION_FIRST;
-				node->set_label(NodeLabel::TOP, terminate_early_);
-			} else {
-				node->label_reason = LabelReason::BAD_ENV_ACTION_FIRST;
-				node->set_label(NodeLabel::BOTTOM, terminate_early_);
-			}
-		}
+		return label_graph(node, controller_actions_, environment_actions_);
 	}
 
 	/** Get the size of the search graph.

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -716,7 +716,7 @@ TEST_CASE("Check a node for unsatisfiable ATA configurations", "[search]")
 	        CanonicalABWord({{TARegionState{Location{"l0"}, "x", 0}, ATARegionState{a, 0}}})}}));
 }
 
-TEST_CASE("Search graph", "[search]")
+TEST_CASE("Search graph with self loops", "[search]")
 {
 	auto root = create_test_node();
 	root->add_child({1, "c"}, root);
@@ -755,6 +755,20 @@ TEST_CASE("Search graph", "[search]")
 		// We can avoid the action by indefinitely following the self loop.
 		CHECK(root->label == NodeLabel::TOP);
 	}
+}
+
+TEST_CASE("Search graph with loops", "[search]")
+{
+	auto root = create_test_node();
+	auto c1   = create_test_node(dummyWords(0));
+	auto c1c1 = create_test_node(dummyWords(1));
+	root->add_child({1, "c"}, c1);
+	c1->add_child({1, "c"}, c1c1);
+	c1c1->add_child({1, "c"}, root);
+	const std::set<std::string> controller_actions{"c"};
+	const std::set<std::string> enviroment_actions{"e1", "e2"};
+	search::label_graph(root.get(), controller_actions, enviroment_actions);
+	CHECK(root->label == NodeLabel::TOP);
 }
 
 } // namespace


### PR DESCRIPTION
If we have some loop of unlabeled nodes, then the label function would
recurse into the children infinitely often. To avoid this, track which
nodes we have already seen and abort the labeling if we have already
visited the current node. This means that if we encounter a loop, then
the whole loop may not obtain a label, as it is possible to just stay in
the loop indefinitely. As no node is labeled with BAD, any node that is
a parent of one of the loop's nodes may be labeled with GOOD (unless
there is some other reason why it is bad). Note that this may also mean
that the controller can just stay in the loop to obtain a winning
strategy.

Note that the first commit simply moves the label function into a free function. The actual fix is in the second commit f73c962f37a5f03e7fcd4da6da2629d9d506cc67.

This is a backport of #141.