### PR TITLE
Switch license to LGPLv3+ and use SPDX identifiers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,361 +1,163 @@
-### GNU GENERAL PUBLIC LICENSE
+GNU Lesser General Public License
+=================================
 
-Version 2, June 1991
+_Version 3, 29 June 2007_  
+_Copyright © 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;_
 
-    Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
-    51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
 
-    Everyone is permitted to copy and distribute verbatim copies
-    of this license document, but changing it is not allowed.
 
-### Preamble
+This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
 
-The licenses for most software are designed to take away your freedom
-to share and change it. By contrast, the GNU General Public License is
-intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users. This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it. (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.) You can apply it to
-your programs, too.
+### 0. Additional Definitions
 
-When we speak of free software, we are referring to freedom, not
-price. Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+As used herein, “this License” refers to version 3 of the GNU Lesser
+General Public License, and the “GNU GPL” refers to version 3 of the GNU
+General Public License.
 
-To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if
-you distribute copies of the software, or if you modify it.
+“The Library” refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
 
-For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have. You must make sure that they, too, receive or can get the
-source code. And you must show them these terms so they know their
-rights.
+An “Application” is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
 
-We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+A “Combined Work” is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the “Linked
+Version”.
 
-Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software. If the software is modified by someone else and passed on,
-we want its recipients to know that what they have is not the
-original, so that any problems introduced by others will not reflect
-on the original authors' reputations.
+The “Minimal Corresponding Source” for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
 
-Finally, any free program is threatened constantly by software
-patents. We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary. To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at
-all.
+The “Corresponding Application Code” for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
 
-The precise terms and conditions for copying, distribution and
-modification follow.
+### 1. Exception to Section 3 of the GNU GPL
 
-### TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
 
-**0.** This License applies to any program or other work which
-contains a notice placed by the copyright holder saying it may be
-distributed under the terms of this General Public License. The
-"Program", below, refers to any such program or work, and a "work
-based on the Program" means either the Program or any derivative work
-under copyright law: that is to say, a work containing the Program or
-a portion of it, either verbatim or with modifications and/or
-translated into another language. (Hereinafter, translation is
-included without limitation in the term "modification".) Each licensee
-is addressed as "you".
+### 2. Conveying Modified Versions
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope. The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the Program
-(independent of having been made by running the Program). Whether that
-is true depends on what the Program does.
+If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
 
-**1.** You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+* **a)** under this License, provided that you make a good faith effort to
+ensure that, in the event an Application does not supply the
+function or data, the facility still operates, and performs
+whatever part of its purpose remains meaningful, or
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a
-fee.
+* **b)** under the GNU GPL, with none of the additional permissions of
+this License applicable to that copy.
 
-**2.** You may modify your copy or copies of the Program or any
-portion of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+### 3. Object Code Incorporating Material from Library Header Files
 
-  
-**a)** You must cause the modified files to carry prominent notices
-stating that you changed the files and the date of any change.
+The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
 
-  
-**b)** You must cause any work that you distribute or publish, that in
-whole or in part contains or is derived from the Program or any part
-thereof, to be licensed as a whole at no charge to all third parties
-under the terms of this License.
+* **a)** Give prominent notice with each copy of the object code that the
+Library is used in it and that the Library and its use are
+covered by this License.
+* **b)** Accompany the object code with a copy of the GNU GPL and this license
+document.
 
-  
-**c)** If the modified program normally reads commands interactively
-when run, you must cause it, when started running for such interactive
-use in the most ordinary way, to print or display an announcement
-including an appropriate copyright notice and a notice that there is
-no warranty (or else, saying that you provide a warranty) and that
-users may redistribute the program under these conditions, and telling
-the user how to view a copy of this License. (Exception: if the
-Program itself is interactive but does not normally print such an
-announcement, your work based on the Program is not required to print
-an announcement.)
+### 4. Combined Works
 
-These requirements apply to the modified work as a whole. If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works. But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote
-it.
+You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+* **a)** Give prominent notice with each copy of the Combined Work that
+the Library is used in it and that the Library and its use are
+covered by this License.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+* **b)** Accompany the Combined Work with a copy of the GNU GPL and this license
+document.
 
-**3.** You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+* **c)** For a Combined Work that displays copyright notices during
+execution, include the copyright notice for the Library among
+these notices, as well as a reference directing the user to the
+copies of the GNU GPL and this license document.
 
-  
-**a)** Accompany it with the complete corresponding machine-readable
-source code, which must be distributed under the terms of Sections 1
-and 2 above on a medium customarily used for software interchange; or,
+* **d)** Do one of the following:
+    - **0)** Convey the Minimal Corresponding Source under the terms of this
+License, and the Corresponding Application Code in a form
+suitable for, and under terms that permit, the user to
+recombine or relink the Application with a modified version of
+the Linked Version to produce a modified Combined Work, in the
+manner specified by section 6 of the GNU GPL for conveying
+Corresponding Source.
+    - **1)** Use a suitable shared library mechanism for linking with the
+Library.  A suitable mechanism is one that **(a)** uses at run time
+a copy of the Library already present on the user's computer
+system, and **(b)** will operate properly with a modified version
+of the Library that is interface-compatible with the Linked
+Version.
 
-  
-**b)** Accompany it with a written offer, valid for at least three
-years, to give any third party, for a charge no more than your cost of
-physically performing source distribution, a complete machine-readable
-copy of the corresponding source code, to be distributed under the
-terms of Sections 1 and 2 above on a medium customarily used for
-software interchange; or,
+* **e)** Provide Installation Information, but only if you would otherwise
+be required to provide such information under section 6 of the
+GNU GPL, and only to the extent that such information is
+necessary to install and execute a modified version of the
+Combined Work produced by recombining or relinking the
+Application with a modified version of the Linked Version. (If
+you use option **4d0**, the Installation Information must accompany
+the Minimal Corresponding Source and Corresponding Application
+Code. If you use option **4d1**, you must provide the Installation
+Information in the manner specified by section 6 of the GNU GPL
+for conveying Corresponding Source.)
 
-  
-**c)** Accompany it with the information you received as to the offer
-to distribute corresponding source code. (This alternative is allowed
-only for noncommercial distribution and only if you received the
-program in object code or executable form with such an offer, in
-accord with Subsection b above.)
+### 5. Combined Libraries
 
-The source code for a work means the preferred form of the work for
-making modifications to it. For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable. However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+* **a)** Accompany the combined library with a copy of the same work based
+on the Library, uncombined with any other library facilities,
+conveyed under the terms of this License.
+* **b)** Give prominent notice with the combined library that part of it
+is a work based on the Library, and explaining where to find the
+accompanying uncombined form of the same work.
 
-**4.** You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License. Any attempt otherwise
-to copy, modify, sublicense or distribute the Program is void, and
-will automatically terminate your rights under this License. However,
-parties who have received copies, or rights, from you under this
-License will not have their licenses terminated so long as such
-parties remain in full compliance.
+### 6. Revised Versions of the GNU Lesser General Public License
 
-**5.** You are not required to accept this License, since you have not
-signed it. However, nothing else grants you permission to modify or
-distribute the Program or its derivative works. These actions are
-prohibited by law if you do not accept this License. Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
-
-**6.** Each time you redistribute the Program (or any work based on
-the Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions. You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
-this License.
-
-**7.** If, as a consequence of a court judgment or allegation of
-patent infringement or for any other reason (not limited to patent
-issues), conditions are imposed on you (whether by court order,
-agreement or otherwise) that contradict the conditions of this
-License, they do not excuse you from the conditions of this License.
-If you cannot distribute so as to satisfy simultaneously your
-obligations under this License and any other pertinent obligations,
-then as a consequence you may not distribute the Program at all. For
-example, if a patent license would not permit royalty-free
-redistribution of the Program by all those who receive copies directly
-or indirectly through you, then the only way you could satisfy both it
-and this License would be to refrain entirely from distribution of the
-Program.
-
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
-
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices. Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
-
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-**8.** If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded. In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-**9.** The Free Software Foundation may publish revised and/or new
-versions of the General Public License from time to time. Such new
+The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.
 
-Each version is given a distinguishing version number. If the Program
-specifies a version number of this License which applies to it and
-"any later version", you have the option of following the terms and
-conditions either of that version or of any later version published by
-the Free Software Foundation. If the Program does not specify a
-version number of this License, you may choose any version ever
-published by the Free Software Foundation.
+Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License “or any later version”
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
 
-**10.** If you wish to incorporate parts of the Program into other
-free programs whose distribution conditions are different, write to
-the author to ask for permission. For software which is copyrighted by
-the Free Software Foundation, write to the Free Software Foundation;
-we sometimes make exceptions for this. Our decision will be guided by
-the two goals of preserving the free status of all derivatives of our
-free software and of promoting the sharing and reuse of software
-generally.
-
-**NO WARRANTY**
-
-**11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
-WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
-EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
-OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY
-KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
-PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
-THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-**12.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
-WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
-AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU
-FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
-CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
-PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
-RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
-SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGES.
-
-### END OF TERMS AND CONDITIONS
-
-### How to Apply These Terms to Your New Programs
-
-If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these
-terms.
-
-To do so, attach the following notices to the program. It is safest to
-attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    one line to give the program's name and an idea of what it does.
-    Copyright (C) yyyy  name of author
-
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License
-    as published by the Free Software Foundation; either version 2
-    of the License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-Also add information on how to contact you by electronic and paper
-mail.
-
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
-
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
-    type `show w'.  This is free software, and you are welcome
-    to redistribute it under certain conditions; type `show c' 
-    for details.
-
-The hypothetical commands \`show w' and \`show c' should show the
-appropriate parts of the General Public License. Of course, the
-commands you use may be called something other than \`show w' and
-\`show c'; they could even be mouse-clicks or menu items--whatever
-suits your program.
-
-You should also get your employer (if you work as a programmer) or
-your school, if any, to sign a "copyright disclaimer" for the program,
-if necessary. Here is a sample; alter the names:
-
-    Yoyodyne, Inc., hereby disclaims all copyright
-    interest in the program `Gnomovision'
-    (which makes passes at compilers) written 
-    by James Hacker.
-
-    signature of Ty Coon, 1 April 1989
-    Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program
-into proprietary programs. If your program is a subroutine library,
-you may consider it more useful to permit linking proprietary
-applications with the library. If this is what you want to do, use the
-[GNU Lesser General Public
-License](https://www.gnu.org/licenses/lgpl.html) instead of this
-License.
+If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 19 Apr 13:43:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/src/app/include/app/app.h
+++ b/src/app/include/app/app.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 19 Apr 15:29:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include <google/protobuf/message.h>
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 19 Apr 16:20:10 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "app/app.h"
 

--- a/src/app/ta_visualizer.cpp
+++ b/src/app/ta_visualizer.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Apr 19:13:45 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "app/app.h"
 #include "automata/ta.pb.h"

--- a/src/automata/ata.cpp
+++ b/src/automata/ata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Fri 05 Jun 2020 11:54:51 CEST 11:54
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ata.h"
 

--- a/src/automata/automata.cpp
+++ b/src/automata/automata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 15:46:12 CEST 15:46
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 

--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -3,20 +3,10 @@
  *
  *  Created: Fri 05 Jun 2020 10:58:27 CEST 10:58
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_H

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 17:49:19 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 13:39:06 CEST 13:39
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 12 Feb 13:19:28 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 14:09:49 CEST 14:09
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H

--- a/src/automata/include/automata/automata.hpp
+++ b/src/automata/include/automata/automata.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Feb 13:30:37 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 26 May 2020 13:44:41 CEST 13:44
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 15 Feb 15:09:10 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 12:49:54 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 12:49:54 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta_proto.h
+++ b/src/automata/include/automata/ta_proto.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 10:31:34 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PROTO_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PROTO_H

--- a/src/automata/include/automata/ta_proto.hpp
+++ b/src/automata/include/automata/ta_proto.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Apr 08:15:44 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta_regions.h
+++ b/src/automata/include/automata/ta_regions.h
@@ -3,19 +3,9 @@
  *
  *  Created: Mon Dec 14 16:36:11 CET 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_REGIONS_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_REGIONS_H

--- a/src/automata/include/automata/ta_regions.hpp
+++ b/src/automata/include/automata/ta_regions.hpp
@@ -3,19 +3,9 @@
  *
  *  Created: Mon Dec 14 16:36:11 CET 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/ta.cpp
+++ b/src/automata/ta.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 26 May 2020 13:44:12 CEST 13:44
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ta.h"
 

--- a/src/automata/ta.proto
+++ b/src/automata/ta.proto
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 10:37:37 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 syntax = "proto3";
 
 package tacos.automata.ta.proto;

--- a/src/automata/ta_proto.cpp
+++ b/src/automata/ta_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 10:50:08 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta_proto.h"
 

--- a/src/automata/ta_regions.cpp
+++ b/src/automata/ta_regions.cpp
@@ -3,19 +3,9 @@
  *
  *  Created: Mon Dec 14 16:36:11 CET 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta_regions.h"
 

--- a/src/gocos/golog_adapter.cpp
+++ b/src/gocos/golog_adapter.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 24 Sep 16:32:37 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "gocos/golog_adapter.h"
 

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -4,19 +4,9 @@
  *
  *  Created:   Tue 19 Oct 15:53:30 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "gocos/golog_program.h"
 

--- a/src/gocos/include/gocos/golog_adapter.h
+++ b/src/gocos/include/gocos/golog_adapter.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 21 Sep 13:47:24 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/gocos/include/gocos/golog_program.h
+++ b/src/gocos/include/gocos/golog_program.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 19 Oct 15:48:45 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu Jun 4 13:13:54 2020 +0200
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 #define SRC_MTL_INCLUDE_MTL_MTLFORMULA_H

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu Jun 4 13:13:54 2020 +0200
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/mtl/include/mtl/mtl_proto.h
+++ b/src/mtl/include/mtl/mtl_proto.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 21:52:29 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/mtl/mtl.proto
+++ b/src/mtl/mtl.proto
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 18:40:05 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 syntax = "proto3";
 

--- a/src/mtl/mtl_proto.cpp
+++ b/src/mtl/mtl_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 18:46:10 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "mtl/mtl_proto.h"
 

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 18 Jun 2020 11:06:49 CEST 11:06
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_MTL_ATA_TRANSLATION_INCLUDE_MTL_ATA_TRANSLATION_TRANSLATOR_H
 #define SRC_MTL_ATA_TRANSLATION_INCLUDE_MTL_ATA_TRANSLATION_TRANSLATOR_H

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 18 Jun 2020 11:21:13 CEST 11:21
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/src/mtl_ata_translation/translator.cpp
+++ b/src/mtl_ata_translation/translator.cpp
@@ -3,19 +3,9 @@
  *
  *  Created: Thu 18 Jun 2020 11:21:13 CEST 11:21
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 // Empty source file to avoid clangd errors with header-only libraries.

--- a/src/search/include/search/adapter.h
+++ b/src/search/include/search/adapter.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 19 Oct 17:38:25 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/canonical_word.h
+++ b/src/search/include/search/canonical_word.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri  5 Mar 16:38:43 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/create_controller.h
+++ b/src/search/include/search/create_controller.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 06 Apr 17:09:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/heuristics.h
+++ b/src/search/include/search/heuristics.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 23 Mar 09:05:55 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H
 #define SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H

--- a/src/search/include/search/operators.h
+++ b/src/search/include/search/operators.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  8 Feb 14:01:53 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/reg_a.h
+++ b/src/search/include/search/reg_a.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri  5 Feb 14:25:02 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Feb 16:21:53 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/search_tree.h
+++ b/src/search/include/search/search_tree.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Feb 15:58:24 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 21 Dec 16:13:49 CET 2020
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/ta_adapter.h
+++ b/src/search/include/search/ta_adapter.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu  9 Sep 09:52:44 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/search_tree.cpp
+++ b/src/search/search_tree.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 26 Mar 11:33:05 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "search/search_tree.h"
 

--- a/src/utilities/graphviz/graph.cpp
+++ b/src/utilities/graphviz/graph.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 14 Apr 22:52:49 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "utilities/graphviz/graphviz.h"
 

--- a/src/utilities/graphviz/include/utilities/graphviz/graphviz.h
+++ b/src/utilities/graphviz/include/utilities/graphviz/graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 14 Apr 22:32:42 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/graphviz/node.cpp
+++ b/src/utilities/graphviz/node.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 15 Apr 2021 15:49:21 CEST 15:49
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "utilities/graphviz/graphviz.h"
 

--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon Dec 7 18:18:28 2020 +0100
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/config.h
+++ b/src/utilities/include/utilities/config.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon Dec 14 16:36:11 2020 +0100
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/numbers.h
+++ b/src/utilities/include/utilities/numbers.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon Dec 7 18:18:28 2020 +0100
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/powerset.h
+++ b/src/utilities/include/utilities/powerset.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 19 Jan 14:43:59 CET 2022
  *  Copyright  2022  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include <set>
 

--- a/src/utilities/include/utilities/priority_thread_pool.h
+++ b/src/utilities/include/utilities/priority_thread_pool.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 10 Mar 22:57:22 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_UTILITIES_INCLUDE_UTILITIES_PRIORITY_THREAD_POOL_H
 #define SRC_UTILITIES_INCLUDE_UTILITIES_PRIORITY_THREAD_POOL_H

--- a/src/utilities/include/utilities/priority_thread_pool.hpp
+++ b/src/utilities/include/utilities/priority_thread_pool.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 10 Mar 23:06:29 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/to_string.h
+++ b/src/utilities/include/utilities/to_string.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Apr 08:20:52 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/types.h
+++ b/src/utilities/include/utilities/types.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu  9 Sep 09:59:47 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/include/visualization/interactive_tree_to_graphviz.h
+++ b/src/visualization/include/visualization/interactive_tree_to_graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri  9 Jul 12:25:26 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/include/visualization/ta_to_graphviz.h
+++ b/src/visualization/include/visualization/ta_to_graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 16 Apr 09:15:33 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/include/visualization/tree_to_graphviz.h
+++ b/src/visualization/include/visualization/tree_to_graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 15 Apr 16:59:15 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/visualization.cpp
+++ b/src/visualization/visualization.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 16 Apr 09:16:07 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "visualization/interactive_tree_to_graphviz.h"
 

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 28 Jul 15:57:02 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include <benchmark/benchmark.h>
 

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -3,19 +3,9 @@
  *
  *  Created: Mon 26 Jul 2021 20:06:42 CEST 13:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@tuwien.ac.at>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 17:18:27 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 26 Jul 18:48:06 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta_product.h"

--- a/test/csma_cd.cpp
+++ b/test/csma_cd.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 22 Apr 2021 19:33:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "csma_cd.h"
 

--- a/test/csma_cd.h
+++ b/test/csma_cd.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 22 Apr 2021 19:33:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/fischer.cpp
+++ b/test/fischer.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Wed 21 Apr 2021 15:07:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "fischer.h"
 

--- a/test/fischer.h
+++ b/test/fischer.h
@@ -3,20 +3,10 @@
  *
  *  Created: Wed 21 Apr 2021 15:07:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/heuristics_generator.h
+++ b/test/heuristics_generator.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 27 Jul 17:25:45 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "search/heuristics.h"
 

--- a/test/railroad.cpp
+++ b/test/railroad.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "railroad.h"
 

--- a/test/railroad.h
+++ b/test/railroad.h
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/railroad_location.cpp
+++ b/test/railroad_location.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/test/railroad_location.h
+++ b/test/railroad_location.h
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 20 Apr 19:57:43 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "app/app.h"
 

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 09 Jun 2020 09:05:03 CEST 09:05
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ata.h"
 #include "automata/ata_formula.h"

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 16:33:29 CEST 16:33
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ata_formula.h"
 #include "automata/automata.h"

--- a/test/test_clock.cpp
+++ b/test/test_clock.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 12:48:44 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 06 Apr 17:09:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_TRACE
 

--- a/test/test_csma_cd.cpp
+++ b/test/test_csma_cd.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu  22 Apr 20:33:27 CET 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/test/test_fischer.cpp
+++ b/test/test_fischer.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed  21 Apr 18:07:27 CET 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 
 #include "automata/automata.h"

--- a/test/test_golog_search.cpp
+++ b/test/test_golog_search.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 19 Oct 14:32:54 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "gocos/golog_adapter.h"
 #include "gocos/golog_program.h"

--- a/test/test_golog_words.cpp
+++ b/test/test_golog_words.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 21 Sep 13:52:54 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "gocos/golog_adapter.h"
 #include "gocos/golog_program.h"

--- a/test/test_graphviz.cpp
+++ b/test/test_graphviz.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 15 Apr 10:20:22 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "catch2/matchers/catch_matchers_string.hpp"
 

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 23 Mar 09:08:56 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta.h"
 #include "automata/ta_regions.h"

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: 4 June 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "utilities/Interval.h"
 

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: 4 June 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Mon 29 Jun 2020 16:33:49 CEST 16:33
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 

--- a/test/test_mtl_proto.cpp
+++ b/test/test_mtl_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 23:53:40 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "mtl/mtl.pb.h"
 #include "utilities/Interval.h"

--- a/test/test_number_utilities.cpp
+++ b/test/test_number_utilities.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: 7 December 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "utilities/numbers.h"
 

--- a/test/test_powerset.cpp
+++ b/test/test_powerset.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 19 Jan 14:49:40 CET 2022
  *  Copyright  2022  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "utilities/powerset.h"
 

--- a/test/test_print_ata.cpp
+++ b/test/test_print_ata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created:   Mon  7 Dec 15:44:03 CET 2020
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ata.h"
 #include "automata/ata_formula.h"

--- a/test/test_print_ata_formula.cpp
+++ b/test/test_print_ata_formula.cpp
@@ -3,20 +3,10 @@
  *
  *  Created:   Fri  4 Dec 14:30:50 CET 2020
  *  Copyright  2020 Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ata_formula.h"
 #include "automata/automata.h"

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 25 Jan 14:36:46 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"

--- a/test/test_priority_thread_pool.cpp
+++ b/test/test_priority_thread_pool.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 11 Mar 09:31:55 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "utilities/priority_thread_pool.h"
 #include "utilities/priority_thread_pool.hpp"

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 17:18:27 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_ERROR
 

--- a/test/test_railroad_location.cpp
+++ b/test/test_railroad_location.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 17:18:27 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Feb 17:23:48 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include "mtl/MTLFormula.h"

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -3,20 +3,10 @@
  *
  *  Created:   Mon 21 Dec 16:56:08 CET 2020
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ata.h"
 #include "automata/automata.h"

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 13:21:10 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 26 May 2020 13:51:10 CEST 13:51
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_ta_print.cpp
+++ b/test/test_ta_print.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 10:22:59 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 13:58:57 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 

--- a/test/test_ta_proto.cpp
+++ b/test/test_ta_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 13:52:14 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_ta_region.cpp
+++ b/test/test_ta_region.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Mon 14 December 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta_regions.h"

--- a/test/test_ta_visualization.cpp
+++ b/test/test_ta_visualization.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 17 Apr 14:45:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_tree_visualization.cpp
+++ b/test/test_tree_visualization.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 15 Apr 20:54:49 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta.h"
 #include "mtl/MTLFormula.h"

--- a/test/test_xml_writer.cpp
+++ b/test/test_xml_writer.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Jul 12:01:49 CEST 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@tuwien.ac.at>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "io/XmlWriter.h"
 


### PR DESCRIPTION
Done automatically with:
```
$ find src test -type f \
  -exec perl -i -p0e 's:/\*\s*This program is free software.*?\*/::se' '{}' \; \
  -exec sed -i '/\s*\*\s*Copyright.*/a \ *  SPDX-License-Identifier: LGPL-3.0-or-later' '{}' \;
```