### PR TITLE
Switch license to LGPLv3+ and use SPDX identifiers

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 19 Apr 13:43:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/src/app/include/app/app.h
+++ b/src/app/include/app/app.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 19 Apr 15:29:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include <google/protobuf/message.h>
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 19 Apr 16:20:10 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "app/app.h"
 

--- a/src/app/ta_visualizer.cpp
+++ b/src/app/ta_visualizer.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Apr 19:13:45 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "app/app.h"
 #include "automata/ta.pb.h"

--- a/src/automata/ata.cpp
+++ b/src/automata/ata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Fri 05 Jun 2020 11:54:51 CEST 11:54
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ata.h"
 

--- a/src/automata/automata.cpp
+++ b/src/automata/automata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 15:46:12 CEST 15:46
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 

--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -3,20 +3,10 @@
  *
  *  Created: Fri 05 Jun 2020 10:58:27 CEST 10:58
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_H

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 17:49:19 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 13:39:06 CEST 13:39
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 12 Feb 13:19:28 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 14:09:49 CEST 14:09
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_AUTOMATA_H

--- a/src/automata/include/automata/automata.hpp
+++ b/src/automata/include/automata/automata.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Feb 13:30:37 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 26 May 2020 13:44:41 CEST 13:44
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_H

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 15 Feb 15:09:10 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta_product.h
+++ b/src/automata/include/automata/ta_product.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 12:49:54 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PRODUCT_H_

--- a/src/automata/include/automata/ta_product.hpp
+++ b/src/automata/include/automata/ta_product.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 12:49:54 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta_proto.h
+++ b/src/automata/include/automata/ta_proto.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 10:31:34 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PROTO_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_PROTO_H

--- a/src/automata/include/automata/ta_proto.hpp
+++ b/src/automata/include/automata/ta_proto.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Apr 08:15:44 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/include/automata/ta_regions.h
+++ b/src/automata/include/automata/ta_regions.h
@@ -3,19 +3,9 @@
  *
  *  Created: Mon Dec 14 16:36:11 CET 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_REGIONS_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_TA_REGIONS_H

--- a/src/automata/include/automata/ta_regions.hpp
+++ b/src/automata/include/automata/ta_regions.hpp
@@ -3,19 +3,9 @@
  *
  *  Created: Mon Dec 14 16:36:11 CET 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/automata/ta.cpp
+++ b/src/automata/ta.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 26 May 2020 13:44:12 CEST 13:44
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ta.h"
 

--- a/src/automata/ta.proto
+++ b/src/automata/ta.proto
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 10:37:37 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 syntax = "proto3";
 
 package tacos.automata.ta.proto;

--- a/src/automata/ta_proto.cpp
+++ b/src/automata/ta_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 10:50:08 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta_proto.h"
 

--- a/src/automata/ta_regions.cpp
+++ b/src/automata/ta_regions.cpp
@@ -3,19 +3,9 @@
  *
  *  Created: Mon Dec 14 16:36:11 CET 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta_regions.h"
 

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu Jun 4 13:13:54 2020 +0200
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 #define SRC_MTL_INCLUDE_MTL_MTLFORMULA_H

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu Jun 4 13:13:54 2020 +0200
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/mtl/include/mtl/mtl_proto.h
+++ b/src/mtl/include/mtl/mtl_proto.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 21:52:29 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/mtl/mtl.proto
+++ b/src/mtl/mtl.proto
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 18:40:05 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 syntax = "proto3";
 

--- a/src/mtl/mtl_proto.cpp
+++ b/src/mtl/mtl_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 18:46:10 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "mtl/mtl_proto.h"
 

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 18 Jun 2020 11:06:49 CEST 11:06
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #ifndef SRC_MTL_ATA_TRANSLATION_INCLUDE_MTL_ATA_TRANSLATION_TRANSLATOR_H
 #define SRC_MTL_ATA_TRANSLATION_INCLUDE_MTL_ATA_TRANSLATION_TRANSLATOR_H

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 18 Jun 2020 11:21:13 CEST 11:21
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/src/mtl_ata_translation/translator.cpp
+++ b/src/mtl_ata_translation/translator.cpp
@@ -3,19 +3,9 @@
  *
  *  Created: Thu 18 Jun 2020 11:21:13 CEST 11:21
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 // Empty source file to avoid clangd errors with header-only libraries.

--- a/src/search/include/search/canonical_word.h
+++ b/src/search/include/search/canonical_word.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri  5 Mar 16:38:43 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/create_controller.h
+++ b/src/search/include/search/create_controller.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 06 Apr 17:09:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/heuristics.h
+++ b/src/search/include/search/heuristics.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 23 Mar 09:05:55 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H
 #define SRC_SYNCHRONOUS_PRODUCT_INCLUDE_SYNCHRONOUS_PRODUCT_HEURISTICS_H

--- a/src/search/include/search/operators.h
+++ b/src/search/include/search/operators.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  8 Feb 14:01:53 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/reg_a.h
+++ b/src/search/include/search/reg_a.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri  5 Feb 14:25:02 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Feb 16:21:53 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/search_tree.h
+++ b/src/search/include/search/search_tree.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Feb 15:58:24 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 21 Dec 16:13:49 CET 2020
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/search/search_tree.cpp
+++ b/src/search/search_tree.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 26 Mar 11:33:05 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "search/search_tree.h"
 

--- a/src/utilities/graphviz/graph.cpp
+++ b/src/utilities/graphviz/graph.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 14 Apr 22:52:49 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "utilities/graphviz/graphviz.h"
 

--- a/src/utilities/graphviz/include/utilities/graphviz/graphviz.h
+++ b/src/utilities/graphviz/include/utilities/graphviz/graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 14 Apr 22:32:42 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/graphviz/node.cpp
+++ b/src/utilities/graphviz/node.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 15 Apr 2021 15:49:21 CEST 15:49
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "utilities/graphviz/graphviz.h"
 

--- a/src/utilities/include/utilities/Interval.h
+++ b/src/utilities/include/utilities/Interval.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon Dec 7 18:18:28 2020 +0100
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/config.h
+++ b/src/utilities/include/utilities/config.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon Dec 14 16:36:11 2020 +0100
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/numbers.h
+++ b/src/utilities/include/utilities/numbers.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon Dec 7 18:18:28 2020 +0100
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/priority_thread_pool.h
+++ b/src/utilities/include/utilities/priority_thread_pool.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 10 Mar 22:57:22 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #ifndef SRC_UTILITIES_INCLUDE_UTILITIES_PRIORITY_THREAD_POOL_H
 #define SRC_UTILITIES_INCLUDE_UTILITIES_PRIORITY_THREAD_POOL_H

--- a/src/utilities/include/utilities/priority_thread_pool.hpp
+++ b/src/utilities/include/utilities/priority_thread_pool.hpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 10 Mar 23:06:29 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/utilities/include/utilities/to_string.h
+++ b/src/utilities/include/utilities/to_string.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Apr 08:20:52 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/include/visualization/interactive_tree_to_graphviz.h
+++ b/src/visualization/include/visualization/interactive_tree_to_graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri  9 Jul 12:25:26 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/include/visualization/ta_to_graphviz.h
+++ b/src/visualization/include/visualization/ta_to_graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 16 Apr 09:15:33 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/include/visualization/tree_to_graphviz.h
+++ b/src/visualization/include/visualization/tree_to_graphviz.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 15 Apr 16:59:15 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #pragma once
 

--- a/src/visualization/visualization.cpp
+++ b/src/visualization/visualization.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 16 Apr 09:16:07 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "visualization/interactive_tree_to_graphviz.h"
 

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed 28 Jul 15:57:02 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include <benchmark/benchmark.h>
 

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -3,19 +3,9 @@
  *
  *  Created: Mon 26 Jul 2021 20:06:42 CEST 13:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@tuwien.ac.at>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 17:18:27 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 26 Jul 18:48:06 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta_product.h"

--- a/test/csma_cd.cpp
+++ b/test/csma_cd.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 22 Apr 2021 19:33:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "csma_cd.h"
 

--- a/test/csma_cd.h
+++ b/test/csma_cd.h
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 22 Apr 2021 19:33:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/fischer.cpp
+++ b/test/fischer.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Wed 21 Apr 2021 15:07:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "fischer.h"
 

--- a/test/fischer.h
+++ b/test/fischer.h
@@ -3,20 +3,10 @@
  *
  *  Created: Wed 21 Apr 2021 15:07:42 CEST 14:00
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/heuristics_generator.h
+++ b/test/heuristics_generator.h
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 27 Jul 17:25:45 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "search/heuristics.h"
 

--- a/test/railroad.cpp
+++ b/test/railroad.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "railroad.h"
 

--- a/test/railroad.h
+++ b/test/railroad.h
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/railroad_location.cpp
+++ b/test/railroad_location.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/test/railroad_location.h
+++ b/test/railroad_location.h
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 20 Apr 2021 13:00:42 CEST 13:00
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #pragma once
 

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 20 Apr 19:57:43 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "app/app.h"
 

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 09 Jun 2020 09:05:03 CEST 09:05
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ata.h"
 #include "automata/ata_formula.h"

--- a/test/test_ata_formula.cpp
+++ b/test/test_ata_formula.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Thu 28 May 2020 16:33:29 CEST 16:33
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/ata_formula.h"
 #include "automata/automata.h"

--- a/test/test_clock.cpp
+++ b/test/test_clock.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 12:48:44 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 06 Apr 17:09:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_TRACE
 

--- a/test/test_csma_cd.cpp
+++ b/test/test_csma_cd.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu  22 Apr 20:33:27 CET 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/test/test_fischer.cpp
+++ b/test/test_fischer.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Wed  21 Apr 18:07:27 CET 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 
 #include "automata/automata.h"

--- a/test/test_graphviz.cpp
+++ b/test/test_graphviz.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 15 Apr 10:20:22 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "catch2/matchers/catch_matchers_string.hpp"
 

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue 23 Mar 09:08:56 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta.h"
 #include "automata/ta_regions.h"

--- a/test/test_interval.cpp
+++ b/test/test_interval.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: 4 June 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "utilities/Interval.h"
 

--- a/test/test_mtlFormula.cpp
+++ b/test/test_mtlFormula.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: 4 June 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Mon 29 Jun 2020 16:33:49 CEST 16:33
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 

--- a/test/test_mtl_proto.cpp
+++ b/test/test_mtl_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 20 Mar 23:53:40 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "mtl/mtl.pb.h"
 #include "utilities/Interval.h"

--- a/test/test_number_utilities.cpp
+++ b/test/test_number_utilities.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: 7 December 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "utilities/numbers.h"
 

--- a/test/test_print_ata.cpp
+++ b/test/test_print_ata.cpp
@@ -3,20 +3,10 @@
  *
  *  Created:   Mon  7 Dec 15:44:03 CET 2020
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ata.h"
 #include "automata/ata_formula.h"

--- a/test/test_print_ata_formula.cpp
+++ b/test/test_print_ata_formula.cpp
@@ -3,20 +3,10 @@
  *
  *  Created:   Fri  4 Dec 14:30:50 CET 2020
  *  Copyright  2020 Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ata_formula.h"
 #include "automata/automata.h"

--- a/test/test_print_mtl_formula.cpp
+++ b/test/test_print_mtl_formula.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon 25 Jan 14:36:46 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "mtl/MTLFormula.h"
 #include "utilities/Interval.h"

--- a/test/test_priority_thread_pool.cpp
+++ b/test/test_priority_thread_pool.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 11 Mar 09:31:55 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "utilities/priority_thread_pool.h"
 #include "utilities/priority_thread_pool.hpp"

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 17:18:27 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_ERROR
 

--- a/test/test_railroad_location.cpp
+++ b/test/test_railroad_location.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 17:18:27 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Feb 17:23:48 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include "mtl/MTLFormula.h"

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -3,20 +3,10 @@
  *
  *  Created:   Mon 21 Dec 16:56:08 CET 2020
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ata.h"
 #include "automata/automata.h"

--- a/test/test_synchronous_product_print.cpp
+++ b/test/test_synchronous_product_print.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 13:21:10 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"

--- a/test/test_ta.cpp
+++ b/test/test_ta.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Tue 26 May 2020 13:51:10 CEST 13:51
  *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_ta_print.cpp
+++ b/test/test_ta_print.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Tue  9 Feb 10:22:59 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_ta_product.cpp
+++ b/test/test_ta_product.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Mon  1 Mar 13:58:57 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 

--- a/test/test_ta_proto.cpp
+++ b/test/test_ta_proto.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Fri 19 Mar 13:52:14 CET 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_ta_region.cpp
+++ b/test/test_ta_region.cpp
@@ -3,20 +3,10 @@
  *
  *  Created: Mon 14 December 2020
  *  Copyright  2020  Stefan Schupp <stefan.schupp@cs.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.GPL file in the doc directory.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta_regions.h"

--- a/test/test_ta_visualization.cpp
+++ b/test/test_ta_visualization.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Sat 17 Apr 14:45:55 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/automata.h"
 #include "automata/ta.h"

--- a/test/test_tree_visualization.cpp
+++ b/test/test_tree_visualization.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 15 Apr 20:54:49 CEST 2021
  *  Copyright  2021  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "automata/ta.h"
 #include "mtl/MTLFormula.h"

--- a/test/test_xml_writer.cpp
+++ b/test/test_xml_writer.cpp
@@ -3,19 +3,9 @@
  *
  *  Created:   Thu 22 Jul 12:01:49 CEST 2021
  *  Copyright  2021  Stefan Schupp <stefan.schupp@tuwien.ac.at>
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
-/*  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
- *
- *  Read the full text in the LICENSE.md file.
- */
+
 
 #include "io/XmlWriter.h"
 


### PR DESCRIPTION
Done automatically with:
```
$ find src test -type f \
  -exec perl -i -p0e 's:/\*\s*This program is free software.*?\*/::se' '{}' \; \
  -exec sed -i '/\s*\*\s*Copyright.*/a \ *  SPDX-License-Identifier: LGPL-3.0-or-later' '{}' \;
```

This is a backport of #143.