### PR TITLE
benchmarks: add cmake flag for large benchmarks, disable by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
     steps:
       - run:
           name: Build the project
-          command: cmake -B build -DTACOS_BUILD_BENCHMARKS=ON && cmake --build build -j $(($(nproc)/8))
+          command: cmake -B build -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON && cmake --build build -j $(($(nproc)/8))
   test:
     steps:
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(GNUInstallDirs)
 include(CTest)
+include(CMakeDependentOption)
 option(TACOS_BUILD_DOC "Allow building documentation, requires doxygen." ON)
 option(TACOS_COVERAGE "Generate coverage report" OFF)
 option(TACOS_BUILD_BENCHMARKS "Build benchmarks" OFF)
+cmake_dependent_option(TACOS_BUILD_LARGE_BENCHMARKS "Run long-running benchmarks" OFF TACOS_BUILD_BENCHMARKS OFF)
 
 add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
 set(CMAKE_CXX_STANDARD 17)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,5 +165,8 @@ if (TACOS_BUILD_BENCHMARKS)
 
   add_executable(tacos_benchmark benchmark.cpp benchmark_robot.cpp benchmark_railroad.cpp benchmark_conveyor_belt.cpp)
   target_link_libraries(tacos_benchmark PRIVATE railroad mtl_ata_translation search benchmark::benchmark)
+  if (TACOS_BUILD_LARGE_BENCHMARKS)
+    target_compile_options(tacos_benchmark PRIVATE "-DBUILD_LARGE_BENCHMARKS")
+  endif()
 
 endif()

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -185,9 +185,12 @@ BENCHMARK_CAPTURE(BM_Robot, weighted_single_thread, true, false)
   ->Args({16, 4, 1})
   ->MeasureProcessCPUTime()
   ->UseRealTime();
+
+#ifdef BUILD_LARGE_BENCHMARKS
 BENCHMARK_CAPTURE(BM_Robot, weighted, true)
   ->ArgsProduct({benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateDenseRange(0, 2, 1)})
   ->MeasureProcessCPUTime()
   ->UseRealTime();
+#endif


### PR DESCRIPTION
This disables the largest benchmarks by default and therefore reduces
the total running time significantly.

This is a backport of #145.