### PR TITLE
Optionally run clang-tidy and fix some clang-tidy warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
             dnf install -y --nodocs \
               << parameters.compiler >> \
               boost-devel \
+              clang-tools-extra \
               cmake \
               doxygen \
               eclipse-clp-devel \
@@ -28,7 +29,7 @@ commands:
     steps:
       - run:
           name: Build the project
-          command: cmake -B build -DTACOS_GOCOS=ON -DTACOS_BUILD_BENCHMARKS=ON && cmake --build build -j $(($(nproc)/8))
+          command: cmake -B build -DTACOS_GOCOS=ON -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_CLANG_TIDY=ON && cmake --build build -j $(($(nproc)/8))
   test:
     steps:
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include(third_party/third_party.cmake)
 add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
 
 if (TACOS_CLANG_TIDY)
-  set(CLANG_TIDY_CHECKS "-checks=-*,bugprone-*")
+  set(CLANG_TIDY_CHECKS "-checks=-*,bugprone-*,-bugprone-easily-swappable-parameters")
   set(CMAKE_CXX_CLANG_TIDY clang-tidy ${CLANG_TIDY_CHECKS}
     -header-filter=${CMAKE_SOURCE_DIR}/src|${CMAKE_SOURCE_DIR}/test
     -warnings-as-errors=*)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,20 @@ option(TACOS_BUILD_DOC "Allow building documentation, requires doxygen." ON)
 option(TACOS_COVERAGE "Generate coverage report" OFF)
 option(TACOS_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(TACOS_GOCOS "Build Golog controller synthesis" OFF)
+option(TACOS_CLANG_TIDY "Run clang-tidy during build" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
 
 include(third_party/third_party.cmake)
 
 add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
+
+if (TACOS_CLANG_TIDY)
+  set(CLANG_TIDY_CHECKS "-checks=-*,bugprone-*")
+  set(CMAKE_CXX_CLANG_TIDY clang-tidy ${CLANG_TIDY_CHECKS}
+    -header-filter=${CMAKE_SOURCE_DIR}/src|${CMAKE_SOURCE_DIR}/test
+    -warnings-as-errors=*)
+endif()
 
 if (TACOS_COVERAGE)
 	include(CodeCoverage)

--- a/src/automata/CMakeLists.txt
+++ b/src/automata/CMakeLists.txt
@@ -28,6 +28,9 @@ if(Protobuf_FOUND)
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>)
+  if (TACOS_CLANG_TIDY)
+    set_property(TARGET ta_proto PROPERTY CXX_CLANG_TIDY "")
+  endif()
   install(
     TARGETS ta_proto
     EXPORT TacosTargets

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -282,10 +282,11 @@ template <typename LocationT, typename AP>
 Endpoint
 TimedAutomaton<LocationT, AP>::get_largest_constant() const
 {
-	Time res{0};
+	Endpoint res{0};
 	for (const auto &[symbol, transition] : transitions_) {
 		for (const auto &[symbol, constraint] : transition.get_guards()) {
-			Time candidate = std::visit([](const auto &c) { return c.get_comparand(); }, constraint);
+			const auto candidate =
+			  std::visit([](const auto &c) { return c.get_comparand(); }, constraint);
 			if (candidate > res) {
 				res = candidate;
 			}

--- a/src/mtl/CMakeLists.txt
+++ b/src/mtl/CMakeLists.txt
@@ -22,6 +22,9 @@ if(Protobuf_FOUND)
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>)
+  if (TACOS_CLANG_TIDY)
+    set_property(TARGET mtl_proto PROPERTY CXX_CLANG_TIDY "")
+  endif()
   install(
     TARGETS mtl_proto
     EXPORT TacosTargets

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -202,17 +202,19 @@ get_candidate(const CanonicalABWord<Location, ConstraintSymbolType> &word)
 			if (std::holds_alternative<PlantRegionState<Location>>(symbol)) {
 				const auto &      ta_region_state = std::get<PlantRegionState<Location>>(symbol);
 				const RegionIndex region_index    = ta_region_state.region_index;
-				const Time        fractional_part = region_index % 2 == 0 ? 0 : time_delta * (i + 1);
-				const Time        integral_part   = static_cast<RegionIndex>(region_index / 2);
-				const auto &      clock_name      = ta_region_state.clock;
+				const Time        fractional_part =
+          region_index % 2 == 0 ? 0 : time_delta * static_cast<Time>((i + 1));
+				const Time  integral_part = static_cast<RegionIndex>(region_index / 2);
+				const auto &clock_name    = ta_region_state.clock;
 				// update ta_configuration
 				plant_configuration.location                     = ta_region_state.location;
 				plant_configuration.clock_valuations[clock_name] = integral_part + fractional_part;
 			} else { // ATARegionState<ConstraintSymbolType>
 				const auto &      ata_region_state = std::get<ATARegionState<ConstraintSymbolType>>(symbol);
 				const RegionIndex region_index     = ata_region_state.region_index;
-				const Time        fractional_part  = region_index % 2 == 0 ? 0 : time_delta * (i + 1);
-				const Time        integral_part    = static_cast<RegionIndex>(region_index / 2);
+				const Time        fractional_part =
+          region_index % 2 == 0 ? 0 : time_delta * static_cast<Time>((i + 1));
+				const Time integral_part = static_cast<RegionIndex>(region_index / 2);
 				// update configuration
 				// TODO check: the formula (aka ConstraintSymbolType) encodes the location, the clock
 				// valuation is separate and a configuration is a set of such pairs. Is this already

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -167,17 +167,6 @@ if (TACOS_COVERAGE)
 endif()
 
 if (TACOS_BUILD_BENCHMARKS)
-  include(FetchContent)
-  FetchContent_Declare(
-    googlebenchmark
-    GIT_REPOSITORY https://github.com/google/benchmark
-    GIT_TAG v1.6.0
-  )
-
-  set(BENCHMARK_ENABLE_TESTING OFF)
-  FetchContent_MakeAvailable(googlebenchmark)
-
   add_executable(tacos_benchmark benchmark.cpp benchmark_robot.cpp benchmark_railroad.cpp benchmark_conveyor_belt.cpp)
   target_link_libraries(tacos_benchmark PRIVATE railroad mtl_ata_translation search benchmark::benchmark)
-
 endif()

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -149,12 +149,14 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 		controller_size += controller.get_locations().size();
 	}
 
-	state.counters["tree_size"] = benchmark::Counter(tree_size, benchmark::Counter::kAvgIterations);
+	state.counters["tree_size"] =
+	  benchmark::Counter(static_cast<double>(tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["pruned_tree_size"] =
-	  benchmark::Counter(pruned_tree_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(pruned_tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["controller_size"] =
-	  benchmark::Counter(controller_size, benchmark::Counter::kAvgIterations);
-	state.counters["plant_size"] = benchmark::Counter(plant_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(controller_size), benchmark::Counter::kAvgIterations);
+	state.counters["plant_size"] =
+	  benchmark::Counter(static_cast<double>(plant_size), benchmark::Counter::kAvgIterations);
 }
 
 BENCHMARK_CAPTURE(BM_ConveyorBelt, single_heuristic, false)

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -62,7 +62,7 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 {
 	spdlog::set_level(spdlog::level::err);
 	spdlog::set_pattern("%t %v");
-	std::vector<Time> distances;
+	std::vector<Endpoint> distances;
 	switch (mode) {
 	case Mode::SIMPLE:
 	case Mode::WEIGHTED: distances = {2, 2}; break;
@@ -145,12 +145,14 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 		  search.get_root(), controller_actions, environment_actions, K, true);
 		controller_size += controller.get_locations().size();
 	}
-	state.counters["tree_size"] = benchmark::Counter(tree_size, benchmark::Counter::kAvgIterations);
+	state.counters["tree_size"] =
+	  benchmark::Counter(static_cast<double>(tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["pruned_tree_size"] =
-	  benchmark::Counter(pruned_tree_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(pruned_tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["controller_size"] =
-	  benchmark::Counter(controller_size, benchmark::Counter::kAvgIterations);
-	state.counters["plant_size"] = benchmark::Counter(plant_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(controller_size), benchmark::Counter::kAvgIterations);
+	state.counters["plant_size"] =
+	  benchmark::Counter(static_cast<double>(plant_size), benchmark::Counter::kAvgIterations);
 }
 
 // Range all over all heuristics individually.

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -164,12 +164,14 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 		  controller_synthesis::create_controller(search.get_root(), camera_actions, robot_actions, K);
 		controller_size += controller.get_locations().size();
 	}
-	state.counters["tree_size"] = benchmark::Counter(tree_size, benchmark::Counter::kAvgIterations);
+	state.counters["tree_size"] =
+	  benchmark::Counter(static_cast<double>(tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["pruned_tree_size"] =
-	  benchmark::Counter(pruned_tree_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(pruned_tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["controller_size"] =
-	  benchmark::Counter(controller_size, benchmark::Counter::kAvgIterations);
-	state.counters["plant_size"] = benchmark::Counter(plant_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(controller_size), benchmark::Counter::kAvgIterations);
+	state.counters["plant_size"] =
+	  benchmark::Counter(static_cast<double>(plant_size), benchmark::Counter::kAvgIterations);
 }
 
 BENCHMARK_CAPTURE(BM_Robot, single_heuristic, false)

--- a/test/csma_cd.cpp
+++ b/test/csma_cd.cpp
@@ -34,7 +34,7 @@ using automata::AtomicClockConstraintT;
 std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_csma_cd_instance(std::size_t count, Time lambda, Time sigma)
+create_csma_cd_instance(std::size_t count, Endpoint lambda, Endpoint sigma)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/csma_cd.h
+++ b/test/csma_cd.h
@@ -31,6 +31,6 @@
 std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_csma_cd_instance(std::size_t count,
-                        tacos::Time delay_self_assign,
-                        tacos::Time delay_enter_critical);
+create_csma_cd_instance(std::size_t     count,
+                        tacos::Endpoint delay_self_assign,
+                        tacos::Endpoint delay_enter_critical);

--- a/test/fischer.cpp
+++ b/test/fischer.cpp
@@ -34,7 +34,9 @@ using automata::AtomicClockConstraintT;
 std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_fischer_instance(std::size_t count, Time delay_self_assign, Time delay_enter_critical)
+create_fischer_instance(std::size_t count,
+                        Endpoint    delay_self_assign,
+                        Endpoint    delay_enter_critical)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/fischer.h
+++ b/test/fischer.h
@@ -31,6 +31,6 @@
 std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_fischer_instance(std::size_t count,
-                        tacos::Time delay_self_assign,
-                        tacos::Time delay_enter_critical);
+create_fischer_instance(std::size_t     count,
+                        tacos::Endpoint delay_self_assign,
+                        tacos::Endpoint delay_enter_critical);

--- a/test/railroad.cpp
+++ b/test/railroad.cpp
@@ -38,7 +38,7 @@ std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            logic::MTLFormula<std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<Time> distances)
+create_crossing_problem(std::vector<Endpoint> distances)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/railroad.h
+++ b/test/railroad.h
@@ -33,4 +33,4 @@ std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::st
            tacos::logic::MTLFormula<std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<tacos::Time> distances);
+create_crossing_problem(std::vector<tacos::Endpoint> distances);

--- a/test/railroad_location.cpp
+++ b/test/railroad_location.cpp
@@ -57,7 +57,7 @@ std::tuple<
   logic::MTLFormula<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>::Location>,
   std::set<std::string>,
   std::set<std::string>>
-create_crossing_problem(std::vector<Time> distances)
+create_crossing_problem(std::vector<Endpoint> distances)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/railroad_location.h
+++ b/test/railroad_location.h
@@ -34,4 +34,4 @@ std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::st
              tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::string>::Location>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<tacos::Time> distances);
+create_crossing_problem(std::vector<tacos::Endpoint> distances);

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -427,11 +427,13 @@ TEST_CASE("ATA must not contain the sink location in any transition", "[ta]")
 	{
 		CHECK_THROWS(AlternatingTimedAutomaton<std::string, std::string>(
 		  {"a", "b"}, "sink", {"s0"}, std::move(transitions), "sink"));
+		transitions.clear();
 	}
 	SECTION("sink in final locations")
 	{
 		CHECK_THROWS(AlternatingTimedAutomaton<std::string, std::string>(
 		  {"a", "b"}, "sink", {"sink"}, std::move(transitions), "sink"));
+		transitions.clear();
 	}
 	SECTION("sink in transition")
 	{
@@ -439,6 +441,7 @@ TEST_CASE("ATA must not contain the sink location in any transition", "[ta]")
 		  "sink", "a", std::make_unique<LocationFormula<std::string>>("s0")));
 		CHECK_THROWS(AlternatingTimedAutomaton<std::string, std::string>(
 		  {"a", "b"}, "sink", {"sink"}, std::move(transitions), "sink"));
+		transitions.clear();
 	}
 }
 

--- a/test/test_csma_cd.cpp
+++ b/test/test_csma_cd.cpp
@@ -54,8 +54,8 @@ TEST_CASE("One process accesses the carrier", "[csma_cd]")
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
 	// parameters
-	const Time sigma  = 1;
-	const Time lambda = 1;
+	const Endpoint sigma  = 1;
+	const Endpoint lambda = 1;
 	// system
 	const auto &[product, controller_actions, environment_actions] =
 	  create_csma_cd_instance(1, sigma, lambda);
@@ -123,8 +123,8 @@ TEST_CASE("Two processes access the carrier", "[csma_cd]")
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
 	// parameters
-	const Time        sigma     = 1;
-	const Time        lambda    = 1;
+	const Endpoint    sigma     = 1;
+	const Endpoint    lambda    = 1;
 	const std::size_t processes = 2;
 	// system
 	const auto &[product, controller_actions, environment_actions] =

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -142,8 +142,8 @@ TEST_CASE("Test CompositeHeuristic", "[search][heuristics]")
 	auto n3 = std::make_shared<Node>(dummy_words);
 	root->add_child({2, "environment_action"}, n3);
 	root->add_child({3, "controller_action"}, n3);
-	auto w_time = GENERATE(0, 1, 10);
-	auto w_env  = GENERATE(0, 1, 10);
+	long w_time = GENERATE(0, 1, 10);
+	long w_env  = GENERATE(0, 1, 10);
 	SECTION(fmt::format("w_time={}, w_env={}", w_time, w_env))
 	{
 		std::vector<std::pair<

--- a/test/test_print_ata.cpp
+++ b/test/test_print_ata.cpp
@@ -101,6 +101,7 @@ TEST_CASE("Print a simple ATA", "[print][ata]")
 		                                                        "s0",
 		                                                        {"s0"},
 		                                                        std::move(transitions));
+		transitions.clear();
 		s << ata;
 		REQUIRE(s.str()
 		        == "Alphabet: {a}, initial location: s0, final locations: {s0}, no sink location, "
@@ -112,6 +113,7 @@ TEST_CASE("Print a simple ATA", "[print][ata]")
 	{
 		AlternatingTimedAutomaton<std::string, std::string> ata(
 		  {"a"}, "s0", {"s0"}, std::move(transitions), "sink");
+		transitions.clear();
 		s << ata;
 		REQUIRE(s.str()
 		        == "Alphabet: {a}, initial location: s0, final locations: {s0}, sink location: sink, "

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -101,8 +101,8 @@ TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 {
 	spdlog::set_level(spdlog::level::debug);
 	spdlog::set_pattern("%t %v");
-	auto distances =
-	  GENERATE(values({std::vector<Time>{2}, std::vector<Time>{2, 2}, std::vector<Time>{2, 4}}));
+	auto distances = GENERATE(
+	  values({std::vector<Endpoint>{2}, std::vector<Endpoint>{2, 2}, std::vector<Endpoint>{2, 4}}));
 	const auto   num_crossings       = distances.size();
 	const auto   problem             = create_crossing_problem(distances);
 	auto         plant               = std::get<0>(problem);

--- a/test/test_railroad_location.cpp
+++ b/test/test_railroad_location.cpp
@@ -86,8 +86,8 @@ generate_heuristic(long                  weight_canonical_words     = 0,
 TEST_CASE("Railroad with two crossings", "[.railroad]")
 {
 	spdlog::set_level(spdlog::level::debug);
-	std::vector<Time> distances     = {4};
-	const auto        num_crossings = distances.size();
+	std::vector<Endpoint> distances     = {4};
+	const auto            num_crossings = distances.size();
 	const auto [plant, spec, controller_actions, environment_actions] =
 	  create_crossing_problem(distances);
 	std::set<std::string> actions;

--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -83,3 +83,13 @@ if(TACOS_GOCOS)
     FetchContent_MakeAvailable(golog++)
   endif()
 endif()
+
+if (TACOS_BUILD_BENCHMARKS)
+  FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark
+    GIT_TAG v1.6.0
+  )
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  FetchContent_MakeAvailable(googlebenchmark)
+endif()


### PR DESCRIPTION
Add a build option to run the build with clang-tidy enabled. For now, only enable some `bugprone` warnings and fix all warnings produced by clang-tidy.