### PR TITLE
Optionally run clang-tidy and fix some clang-tidy warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ commands:
             dnf install -y --nodocs \
               << parameters.compiler >> \
               boost-devel \
+              clang-tools-extra \
               cmake \
               doxygen \
               git \
@@ -25,7 +26,7 @@ commands:
     steps:
       - run:
           name: Build the project
-          command: cmake -B build -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON && cmake --build build -j $(($(nproc)/8))
+          command: cmake -B build -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON -DTACOS_CLANG_TIDY=ON && cmake --build build -j $(($(nproc)/8))
   test:
     steps:
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,19 @@ option(TACOS_BUILD_DOC "Allow building documentation, requires doxygen." ON)
 option(TACOS_COVERAGE "Generate coverage report" OFF)
 option(TACOS_BUILD_BENCHMARKS "Build benchmarks" OFF)
 cmake_dependent_option(TACOS_BUILD_LARGE_BENCHMARKS "Run long-running benchmarks" OFF TACOS_BUILD_BENCHMARKS OFF)
+option(TACOS_CLANG_TIDY "Run clang-tidy during build" OFF)
 
 add_compile_options(-W -Wall -Werror -Wextra -Wpedantic)
 set(CMAKE_CXX_STANDARD 17)
 
 include(third_party/third_party.cmake)
+
+if (TACOS_CLANG_TIDY)
+  set(CLANG_TIDY_CHECKS "-checks=-*,bugprone-*")
+  set(CMAKE_CXX_CLANG_TIDY clang-tidy ${CLANG_TIDY_CHECKS}
+    -header-filter=${CMAKE_SOURCE_DIR}/src|${CMAKE_SOURCE_DIR}/test
+    -warnings-as-errors=*)
+endif()
 
 if (TACOS_COVERAGE)
 	include(CodeCoverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD 17)
 include(third_party/third_party.cmake)
 
 if (TACOS_CLANG_TIDY)
-  set(CLANG_TIDY_CHECKS "-checks=-*,bugprone-*")
+  set(CLANG_TIDY_CHECKS "-checks=-*,bugprone-*,-bugprone-easily-swappable-parameters")
   set(CMAKE_CXX_CLANG_TIDY clang-tidy ${CLANG_TIDY_CHECKS}
     -header-filter=${CMAKE_SOURCE_DIR}/src|${CMAKE_SOURCE_DIR}/test
     -warnings-as-errors=*)

--- a/src/automata/CMakeLists.txt
+++ b/src/automata/CMakeLists.txt
@@ -28,6 +28,9 @@ if(Protobuf_FOUND)
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>)
+  if (TACOS_CLANG_TIDY)
+    set_property(TARGET ta_proto PROPERTY CXX_CLANG_TIDY "")
+  endif()
   install(
     TARGETS ta_proto
     EXPORT TacosTargets

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -473,7 +473,7 @@ public:
 	 * @brief Get the largest constant any clock is compared to.
 	 * @return Time
 	 */
-	Time get_largest_constant() const;
+	Endpoint get_largest_constant() const;
 
 	/** Get the initial configuration of the automaton.
 	 * @return The initial configuration

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -305,10 +305,11 @@ template <typename LocationT, typename AP>
 Time
 TimedAutomaton<LocationT, AP>::get_largest_constant() const
 {
-	Time res{0};
+	Endpoint res{0};
 	for (const auto &[symbol, transition] : transitions_) {
 		for (const auto &[symbol, constraint] : transition.get_guards()) {
-			Time candidate = std::visit([](const auto &c) { return c.get_comparand(); }, constraint);
+			const auto candidate =
+			  std::visit([](const auto &c) { return c.get_comparand(); }, constraint);
 			if (candidate > res) {
 				res = candidate;
 			}

--- a/src/automata/include/automata/ta.hpp
+++ b/src/automata/include/automata/ta.hpp
@@ -302,7 +302,7 @@ TimedAutomaton<LocationT, AP>::get_enabled_transitions(
 }
 
 template <typename LocationT, typename AP>
-Time
+Endpoint
 TimedAutomaton<LocationT, AP>::get_largest_constant() const
 {
 	Endpoint res{0};

--- a/src/mtl/CMakeLists.txt
+++ b/src/mtl/CMakeLists.txt
@@ -22,6 +22,9 @@ if(Protobuf_FOUND)
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>)
+  if (TACOS_CLANG_TIDY)
+    set_property(TARGET mtl_proto PROPERTY CXX_CLANG_TIDY "")
+  endif()
   install(
     TARGETS mtl_proto
     EXPORT TacosTargets

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -20,6 +20,7 @@
 #ifndef SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 #define SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 
+#include "automata/automata.h"
 #include "utilities/Interval.h"
 
 #include <algorithm>
@@ -35,7 +36,7 @@
 namespace tacos::logic {
 
 /// An interval endpoint used for constrained until and dual until operators.
-using TimePoint = double;
+using TimePoint = automata::Endpoint;
 /// An interval used for constrained until and dual until operators.
 using TimeInterval = utilities::arithmetic::Interval<TimePoint>;
 

--- a/src/mtl/include/mtl/MTLFormula.hpp
+++ b/src/mtl/include/mtl/MTLFormula.hpp
@@ -370,7 +370,7 @@ MTLFormula<APType>::get_largest_constant() const
 	case LOP::LAND:
 	case LOP::LOR:
 		for (const auto &sub_formula : operands_) {
-			largest_constant = std::max(0., sub_formula.get_largest_constant());
+			largest_constant = std::max(TimePoint{0}, sub_formula.get_largest_constant());
 		}
 		break;
 	case LOP::LUNTIL:

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -38,7 +38,6 @@ using logic::AtomicProposition;
 using logic::LOP;
 using logic::MTLFormula;
 using logic::TimeInterval;
-using logic::TimePoint;
 
 ///@{
 /// Formulas are always ATA formulas over MTLFormulas.
@@ -97,19 +96,19 @@ create_contains(TimeInterval duration)
 	if (duration.lowerBoundType() != BoundType::INFTY) {
 		if (duration.lowerBoundType() == BoundType::WEAK) {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater_equal<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::greater_equal<Time>>(duration.lower()));
 		} else {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::greater<Time>>(duration.lower()));
 		}
 	}
 	if (duration.upperBoundType() != BoundType::INFTY) {
 		if (duration.upperBoundType() == BoundType::WEAK) {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less_equal<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::less_equal<Time>>(duration.upper()));
 		} else {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::less<Time>>(duration.upper()));
 		}
 	}
 	return ata::create_conjunction(std::move(lowerBound), std::move(upperBound));
@@ -127,19 +126,19 @@ create_negated_contains(TimeInterval duration)
 	if (duration.lowerBoundType() != BoundType::INFTY) {
 		if (duration.lowerBoundType() == BoundType::WEAK) {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::less<Time>>(duration.lower()));
 		} else {
 			lowerBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::less_equal<TimePoint>>(duration.lower()));
+			  AtomicClockConstraintT<std::less_equal<Time>>(duration.lower()));
 		}
 	}
 	if (duration.upperBoundType() != BoundType::INFTY) {
 		if (duration.upperBoundType() == BoundType::WEAK) {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::greater<Time>>(duration.upper()));
 		} else {
 			upperBound = std::make_unique<ClockConstraintFormula<ConstraintSymbolT>>(
-			  AtomicClockConstraintT<std::greater_equal<TimePoint>>(duration.upper()));
+			  AtomicClockConstraintT<std::greater_equal<Time>>(duration.upper()));
 		}
 	}
 	return ata::create_disjunction(std::move(lowerBound), std::move(upperBound));

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -391,17 +391,19 @@ get_candidate(const CanonicalABWord<Location, ConstraintSymbolType> &word)
 			if (std::holds_alternative<TARegionState<Location>>(symbol)) {
 				const auto &      ta_region_state = std::get<TARegionState<Location>>(symbol);
 				const RegionIndex region_index    = ta_region_state.region_index;
-				const Time        fractional_part = region_index % 2 == 0 ? 0 : time_delta * (i + 1);
-				const Time        integral_part   = static_cast<RegionIndex>(region_index / 2);
-				const auto &      clock_name      = ta_region_state.clock;
+				const Time        fractional_part =
+          region_index % 2 == 0 ? 0 : time_delta * static_cast<Time>((i + 1));
+				const Time  integral_part = static_cast<RegionIndex>(region_index / 2);
+				const auto &clock_name    = ta_region_state.clock;
 				// update ta_configuration
 				ta_configuration.location                     = ta_region_state.location;
 				ta_configuration.clock_valuations[clock_name] = integral_part + fractional_part;
 			} else { // ATARegionState<ConstraintSymbolType>
 				const auto &      ata_region_state = std::get<ATARegionState<ConstraintSymbolType>>(symbol);
 				const RegionIndex region_index     = ata_region_state.region_index;
-				const Time        fractional_part  = region_index % 2 == 0 ? 0 : time_delta * (i + 1);
-				const Time        integral_part    = static_cast<RegionIndex>(region_index / 2);
+				const Time        fractional_part =
+          region_index % 2 == 0 ? 0 : time_delta * static_cast<Time>((i + 1));
+				const Time integral_part = static_cast<RegionIndex>(region_index / 2);
 				// update configuration
 				// TODO check: the formula (aka ConstraintSymbolType) encodes the location, the clock
 				// valuation is separate and a configuration is a set of such pairs. Is this already

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,20 +153,9 @@ if (TACOS_COVERAGE)
 endif()
 
 if (TACOS_BUILD_BENCHMARKS)
-  include(FetchContent)
-  FetchContent_Declare(
-    googlebenchmark
-    GIT_REPOSITORY https://github.com/google/benchmark
-    GIT_TAG v1.6.0
-  )
-
-  set(BENCHMARK_ENABLE_TESTING OFF)
-  FetchContent_MakeAvailable(googlebenchmark)
-
   add_executable(tacos_benchmark benchmark.cpp benchmark_robot.cpp benchmark_railroad.cpp benchmark_conveyor_belt.cpp)
   target_link_libraries(tacos_benchmark PRIVATE railroad mtl_ata_translation search benchmark::benchmark)
   if (TACOS_BUILD_LARGE_BENCHMARKS)
     target_compile_options(tacos_benchmark PRIVATE "-DBUILD_LARGE_BENCHMARKS")
   endif()
-
 endif()

--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -149,12 +149,14 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 		controller_size += controller.get_locations().size();
 	}
 
-	state.counters["tree_size"] = benchmark::Counter(tree_size, benchmark::Counter::kAvgIterations);
+	state.counters["tree_size"] =
+	  benchmark::Counter(static_cast<double>(tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["pruned_tree_size"] =
-	  benchmark::Counter(pruned_tree_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(pruned_tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["controller_size"] =
-	  benchmark::Counter(controller_size, benchmark::Counter::kAvgIterations);
-	state.counters["plant_size"] = benchmark::Counter(plant_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(controller_size), benchmark::Counter::kAvgIterations);
+	state.counters["plant_size"] =
+	  benchmark::Counter(static_cast<double>(plant_size), benchmark::Counter::kAvgIterations);
 }
 
 BENCHMARK_CAPTURE(BM_ConveyorBelt, single_heuristic, false)

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -48,6 +48,7 @@ enum class Mode {
 
 using namespace tacos;
 
+using automata::Endpoint;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
@@ -61,7 +62,7 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 {
 	spdlog::set_level(spdlog::level::err);
 	spdlog::set_pattern("%t %v");
-	std::vector<Time> distances;
+	std::vector<Endpoint> distances;
 	switch (mode) {
 	case Mode::SIMPLE:
 	case Mode::WEIGHTED: distances = {2, 2}; break;
@@ -144,12 +145,14 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 		  search.get_root(), controller_actions, environment_actions, K, true);
 		controller_size += controller.get_locations().size();
 	}
-	state.counters["tree_size"] = benchmark::Counter(tree_size, benchmark::Counter::kAvgIterations);
+	state.counters["tree_size"] =
+	  benchmark::Counter(static_cast<double>(tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["pruned_tree_size"] =
-	  benchmark::Counter(pruned_tree_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(pruned_tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["controller_size"] =
-	  benchmark::Counter(controller_size, benchmark::Counter::kAvgIterations);
-	state.counters["plant_size"] = benchmark::Counter(plant_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(controller_size), benchmark::Counter::kAvgIterations);
+	state.counters["plant_size"] =
+	  benchmark::Counter(static_cast<double>(plant_size), benchmark::Counter::kAvgIterations);
 }
 
 // Range all over all heuristics individually.

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -164,12 +164,14 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 		  controller_synthesis::create_controller(search.get_root(), camera_actions, robot_actions, K);
 		controller_size += controller.get_locations().size();
 	}
-	state.counters["tree_size"] = benchmark::Counter(tree_size, benchmark::Counter::kAvgIterations);
+	state.counters["tree_size"] =
+	  benchmark::Counter(static_cast<double>(tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["pruned_tree_size"] =
-	  benchmark::Counter(pruned_tree_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(pruned_tree_size), benchmark::Counter::kAvgIterations);
 	state.counters["controller_size"] =
-	  benchmark::Counter(controller_size, benchmark::Counter::kAvgIterations);
-	state.counters["plant_size"] = benchmark::Counter(plant_size, benchmark::Counter::kAvgIterations);
+	  benchmark::Counter(static_cast<double>(controller_size), benchmark::Counter::kAvgIterations);
+	state.counters["plant_size"] =
+	  benchmark::Counter(static_cast<double>(plant_size), benchmark::Counter::kAvgIterations);
 }
 
 BENCHMARK_CAPTURE(BM_Robot, single_heuristic, false)

--- a/test/csma_cd.cpp
+++ b/test/csma_cd.cpp
@@ -26,6 +26,7 @@
 
 using namespace tacos;
 
+using automata::Endpoint;
 using automata::Time;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
@@ -35,7 +36,7 @@ using automata::AtomicClockConstraintT;
 std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_csma_cd_instance(std::size_t count, Time lambda, Time sigma)
+create_csma_cd_instance(std::size_t count, Endpoint lambda, Endpoint sigma)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/csma_cd.h
+++ b/test/csma_cd.h
@@ -31,6 +31,6 @@
 std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_csma_cd_instance(std::size_t           count,
-                        tacos::automata::Time delay_self_assign,
-                        tacos::automata::Time delay_enter_critical);
+create_csma_cd_instance(std::size_t               count,
+                        tacos::automata::Endpoint delay_self_assign,
+                        tacos::automata::Endpoint delay_enter_critical);

--- a/test/fischer.cpp
+++ b/test/fischer.cpp
@@ -26,6 +26,7 @@
 
 using namespace tacos;
 
+using automata::Endpoint;
 using automata::Time;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
@@ -35,7 +36,9 @@ using automata::AtomicClockConstraintT;
 std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_fischer_instance(std::size_t count, Time delay_self_assign, Time delay_enter_critical)
+create_fischer_instance(std::size_t count,
+                        Endpoint    delay_self_assign,
+                        Endpoint    delay_enter_critical)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/fischer.h
+++ b/test/fischer.h
@@ -31,6 +31,6 @@
 std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_fischer_instance(std::size_t           count,
-                        tacos::automata::Time delay_self_assign,
-                        tacos::automata::Time delay_enter_critical);
+create_fischer_instance(std::size_t               count,
+                        tacos::automata::Endpoint delay_self_assign,
+                        tacos::automata::Endpoint delay_enter_critical);

--- a/test/railroad.cpp
+++ b/test/railroad.cpp
@@ -27,6 +27,7 @@
 
 using namespace tacos;
 
+using automata::Endpoint;
 using automata::Time;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
@@ -39,7 +40,7 @@ std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            logic::MTLFormula<std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<Time> distances)
+create_crossing_problem(std::vector<Endpoint> distances)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/railroad.h
+++ b/test/railroad.h
@@ -33,4 +33,4 @@ std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::st
            tacos::logic::MTLFormula<std::string>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<tacos::automata::Time> distances);
+create_crossing_problem(std::vector<tacos::automata::Endpoint> distances);

--- a/test/railroad_location.cpp
+++ b/test/railroad_location.cpp
@@ -31,6 +31,7 @@
 
 using namespace tacos;
 
+using automata::Endpoint;
 using automata::Time;
 
 using Location        = automata::ta::Location<std::string>;
@@ -58,7 +59,7 @@ std::tuple<automata::ta::TimedAutomaton<std::vector<std::string>, std::string>,
            logic::MTLFormula<std::vector<std::string>>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<Time> distances)
+create_crossing_problem(std::vector<Endpoint> distances)
 {
 	std::vector<TA>         automata;
 	std::set<std::string>   controller_actions;

--- a/test/railroad_location.h
+++ b/test/railroad_location.h
@@ -33,4 +33,4 @@ std::tuple<tacos::automata::ta::TimedAutomaton<std::vector<std::string>, std::st
            tacos::logic::MTLFormula<std::vector<std::string>>,
            std::set<std::string>,
            std::set<std::string>>
-create_crossing_problem(std::vector<tacos::automata::Time> distances);
+create_crossing_problem(std::vector<tacos::automata::Endpoint> distances);

--- a/test/test_ata.cpp
+++ b/test/test_ata.cpp
@@ -431,11 +431,13 @@ TEST_CASE("ATA must not contain the sink location in any transition", "[ta]")
 	{
 		CHECK_THROWS(AlternatingTimedAutomaton<std::string, std::string>(
 		  {"a", "b"}, "sink", {"s0"}, std::move(transitions), "sink"));
+		transitions.clear();
 	}
 	SECTION("sink in final locations")
 	{
 		CHECK_THROWS(AlternatingTimedAutomaton<std::string, std::string>(
 		  {"a", "b"}, "sink", {"sink"}, std::move(transitions), "sink"));
+		transitions.clear();
 	}
 	SECTION("sink in transition")
 	{
@@ -443,6 +445,7 @@ TEST_CASE("ATA must not contain the sink location in any transition", "[ta]")
 		  "sink", "a", std::make_unique<LocationFormula<std::string>>("s0")));
 		CHECK_THROWS(AlternatingTimedAutomaton<std::string, std::string>(
 		  {"a", "b"}, "sink", {"sink"}, std::move(transitions), "sink"));
+		transitions.clear();
 	}
 }
 

--- a/test/test_csma_cd.cpp
+++ b/test/test_csma_cd.cpp
@@ -38,6 +38,7 @@
 namespace {
 using namespace tacos;
 
+using automata::Endpoint;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
@@ -53,8 +54,8 @@ TEST_CASE("One process accesses the carrier", "[csma_cd]")
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
 	// parameters
-	const Time sigma  = 1;
-	const Time lambda = 1;
+	const Endpoint sigma  = 1;
+	const Endpoint lambda = 1;
 	// system
 	const auto &[product, controller_actions, environment_actions] =
 	  create_csma_cd_instance(1, sigma, lambda);
@@ -122,8 +123,8 @@ TEST_CASE("Two processes access the carrier", "[csma_cd]")
 	spdlog::set_level(spdlog::level::trace);
 	spdlog::set_pattern("%t %v");
 	// parameters
-	const Time        sigma     = 1;
-	const Time        lambda    = 1;
+	const Endpoint    sigma     = 1;
+	const Endpoint    lambda    = 1;
 	const std::size_t processes = 2;
 	// system
 	const auto &[product, controller_actions, environment_actions] =

--- a/test/test_heuristics.cpp
+++ b/test/test_heuristics.cpp
@@ -142,8 +142,8 @@ TEST_CASE("Test CompositeHeuristic", "[search][heuristics]")
 	auto n3 = std::make_shared<Node>(dummy_words);
 	root->add_child({2, "environment_action"}, n3);
 	root->add_child({3, "controller_action"}, n3);
-	auto w_time = GENERATE(0, 1, 10);
-	auto w_env  = GENERATE(0, 1, 10);
+	long w_time = GENERATE(0, 1, 10);
+	long w_env  = GENERATE(0, 1, 10);
 	SECTION(fmt::format("w_time={}, w_env={}", w_time, w_env))
 	{
 		std::vector<std::pair<

--- a/test/test_print_ata.cpp
+++ b/test/test_print_ata.cpp
@@ -101,6 +101,7 @@ TEST_CASE("Print a simple ATA", "[print][ata]")
 		                                                        "s0",
 		                                                        {"s0"},
 		                                                        std::move(transitions));
+		transitions.clear();
 		s << ata;
 		REQUIRE(s.str()
 		        == "Alphabet: {a}, initial location: s0, final locations: {s0}, no sink location, "
@@ -112,6 +113,7 @@ TEST_CASE("Print a simple ATA", "[print][ata]")
 	{
 		AlternatingTimedAutomaton<std::string, std::string> ata(
 		  {"a"}, "s0", {"s0"}, std::move(transitions), "sink");
+		transitions.clear();
 		s << ata;
 		REQUIRE(s.str()
 		        == "Alphabet: {a}, initial location: s0, final locations: {s0}, sink location: sink, "

--- a/test/test_railroad.cpp
+++ b/test/test_railroad.cpp
@@ -52,6 +52,7 @@ namespace {
 
 using namespace tacos;
 
+using automata::Endpoint;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
@@ -102,8 +103,8 @@ TEST_CASE("Railroad crossing benchmark", "[.benchmark][railroad]")
 {
 	spdlog::set_level(spdlog::level::debug);
 	spdlog::set_pattern("%t %v");
-	auto distances =
-	  GENERATE(values({std::vector<Time>{2}, std::vector<Time>{2, 2}, std::vector<Time>{2, 4}}));
+	auto distances = GENERATE(
+	  values({std::vector<Endpoint>{2}, std::vector<Endpoint>{2, 2}, std::vector<Endpoint>{2, 4}}));
 	const auto   num_crossings       = distances.size();
 	const auto   problem             = create_crossing_problem(distances);
 	auto         plant               = std::get<0>(problem);

--- a/test/test_railroad_location.cpp
+++ b/test/test_railroad_location.cpp
@@ -51,6 +51,7 @@ namespace {
 
 using namespace tacos;
 
+using automata::Endpoint;
 using Location   = automata::ta::Location<std::string>;
 using TA         = automata::ta::TimedAutomaton<std::string, std::string>;
 using Transition = automata::ta::Transition<std::string, std::string>;
@@ -87,8 +88,8 @@ generate_heuristic(long                  weight_canonical_words     = 0,
 TEST_CASE("Railroad with two crossings", "[.railroad]")
 {
 	spdlog::set_level(spdlog::level::debug);
-	std::vector<Time> distances     = {4};
-	const auto        num_crossings = distances.size();
+	std::vector<Endpoint> distances     = {4};
+	const auto            num_crossings = distances.size();
 	const auto [plant, spec, controller_actions, environment_actions] =
 	  create_crossing_problem(distances);
 	std::set<std::string> actions;

--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -75,3 +75,13 @@ else()
   list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 endif()
 include(Catch)
+
+if (TACOS_BUILD_BENCHMARKS)
+  FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark
+    GIT_TAG v1.6.0
+  )
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  FetchContent_MakeAvailable(googlebenchmark)
+endif()


### PR DESCRIPTION
Add a build option to run the build with clang-tidy enabled. For now, only enable some `bugprone` warnings and fix all warnings produced by clang-tidy.

This is a backport of #147.