### PR TITLE
benchmarks: mark scaled railroad (instead of robot) as large benchmark

### DIFF
--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #include "automata/automata.h"
 #include "automata/ta.h"
 #include "automata/ta_product.h"
@@ -172,9 +171,12 @@ BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
   ->ArgsProduct({benchmark::CreateRange(1, 8, 2), benchmark::CreateRange(1, 8, 2), {0}})
   ->MeasureProcessCPUTime()
   ->UseRealTime();
+
+#ifdef BUILD_LARGE_BENCHMARKS
 BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
   ->Args({1, 1, 1})
   ->Args({2, 1, 1})
   ->Args({2, 2, 2})
   ->MeasureProcessCPUTime()
   ->UseRealTime();
+#endif

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #include "automata/automata.h"
 #include "automata/ta_product.h"
 #include "heuristics_generator.h"
@@ -178,11 +177,9 @@ BENCHMARK_CAPTURE(BM_Robot, weighted_single_thread, true, false)
   ->MeasureProcessCPUTime()
   ->UseRealTime();
 
-#ifdef BUILD_LARGE_BENCHMARKS
 BENCHMARK_CAPTURE(BM_Robot, weighted, true)
   ->ArgsProduct({benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateDenseRange(0, 2, 1)})
   ->MeasureProcessCPUTime()
   ->UseRealTime();
-#endif


### PR DESCRIPTION
The robot benchmark is not large. Instead, railroad scaled should have
been marked as large.

This is a backport of #149.