### PR TITLE
Fix MTL->ATA Translation for conjunctions and disjunctions with >2 subformulas

### DIFF
--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -6,8 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
-
 #ifndef SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H
 #define SRC_AUTOMATA_INCLUDE_AUTOMATA_ATA_FORMULA_H
 
@@ -336,6 +334,11 @@ template <typename LocationT>
 std::unique_ptr<Formula<LocationT>>
 create_disjunction(std::unique_ptr<Formula<LocationT>> disjunct1,
                    std::unique_ptr<Formula<LocationT>> disjunct2);
+
+/** @brief Create a disjunction of a vector of formulas. */
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_disjunction(std::vector<std::unique_ptr<Formula<LocationT>>> disjuncts);
 
 } // namespace tacos::automata::ata
 

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -340,6 +340,11 @@ template <typename LocationT>
 std::unique_ptr<Formula<LocationT>>
 create_disjunction(std::vector<std::unique_ptr<Formula<LocationT>>> disjuncts);
 
+/** @brief Create a conjunction of a vector of formulas. */
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_conjunction(std::vector<std::unique_ptr<Formula<LocationT>>> conjuncts);
+
 } // namespace tacos::automata::ata
 
 #include "ata_formula.hpp"

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -343,6 +343,18 @@ create_disjunction(typename std::vector<std::unique_ptr<Formula<LocationT>>>::it
 	                          create_disjunction<LocationT>(std::next(first), last));
 }
 
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_conjunction(typename std::vector<std::unique_ptr<Formula<LocationT>>>::iterator first,
+                   typename std::vector<std::unique_ptr<Formula<LocationT>>>::iterator last)
+{
+	if (first == last) {
+		return std::make_unique<TrueFormula<LocationT>>();
+	}
+	return create_conjunction(std::move(*first),
+	                          create_conjunction<LocationT>(std::next(first), last));
+}
+
 } // namespace details
 
 template <typename LocationT>
@@ -350,6 +362,13 @@ std::unique_ptr<Formula<LocationT>>
 create_disjunction(std::vector<std::unique_ptr<Formula<LocationT>>> disjuncts)
 {
 	return details::create_disjunction<LocationT>(std::begin(disjuncts), std::end(disjuncts));
+}
+
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_conjunction(std::vector<std::unique_ptr<Formula<LocationT>>> conjuncts)
+{
+	return details::create_conjunction<LocationT>(std::begin(conjuncts), std::end(conjuncts));
 }
 
 } // namespace tacos::automata::ata

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #pragma once
 
 #include "ata_formula.h"
@@ -329,6 +328,28 @@ create_disjunction(std::unique_ptr<Formula<LocationT>> disjunct1,
 	}
 	return std::make_unique<DisjunctionFormula<LocationT>>(std::move(disjunct1),
 	                                                       std::move(disjunct2));
+}
+
+namespace details {
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_disjunction(typename std::vector<std::unique_ptr<Formula<LocationT>>>::iterator first,
+                   typename std::vector<std::unique_ptr<Formula<LocationT>>>::iterator last)
+{
+	if (first == last) {
+		return std::make_unique<FalseFormula<LocationT>>();
+	}
+	return create_disjunction(std::move(*first),
+	                          create_disjunction<LocationT>(std::next(first), last));
+}
+
+} // namespace details
+
+template <typename LocationT>
+std::unique_ptr<Formula<LocationT>>
+create_disjunction(std::vector<std::unique_ptr<Formula<LocationT>>> disjuncts)
+{
+	return details::create_disjunction<LocationT>(std::begin(disjuncts), std::end(disjuncts));
 }
 
 } // namespace tacos::automata::ata

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -6,8 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
-
 #pragma once
 
 #include "automata/ata.h"
@@ -157,10 +155,14 @@ init(const MTLFormula<ConstraintSymbolT> &       formula,
 		// init(psi_1 AND psi_2, a) = init(psi_1, a) AND init(psi_2, a)
 		return ata::create_conjunction(init(formula.get_operands().front(), ap, first),
 		                               init(formula.get_operands().back(), ap, first));
-	case LOP::LOR:
+	case LOP::LOR: {
 		// init(psi_1 OR psi_2, a) = init(psi_1, a) OR init(psi_2, a)
-		return ata::create_disjunction(init(formula.get_operands().front(), ap, first),
-		                               init(formula.get_operands().back(), ap, first));
+		std::vector<std::unique_ptr<Formula<ConstraintSymbolT>>> disjuncts;
+		for (const auto &disjunct : formula.get_operands()) {
+			disjuncts.push_back(init(disjunct, ap, first));
+		}
+		return ata::create_disjunction(std::move(disjuncts));
+	}
 	case LOP::AP:
 		if (formula == ap) {
 			// init(b, a) = TRUE if b == a

--- a/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
+++ b/src/mtl_ata_translation/include/mtl_ata_translation/translator.hpp
@@ -151,10 +151,13 @@ init(const MTLFormula<ConstraintSymbolT> &       formula,
 			return std::make_unique<ResetClockFormula<ConstraintSymbolT>>(
 			  std::make_unique<LocationFormula<ConstraintSymbolT>>(formula));
 		}
-	case LOP::LAND:
-		// init(psi_1 AND psi_2, a) = init(psi_1, a) AND init(psi_2, a)
-		return ata::create_conjunction(init(formula.get_operands().front(), ap, first),
-		                               init(formula.get_operands().back(), ap, first));
+	case LOP::LAND: {
+		std::vector<std::unique_ptr<Formula<ConstraintSymbolT>>> conjuncts;
+		for (const auto &conjunct : formula.get_operands()) {
+			conjuncts.push_back(init(conjunct, ap, first));
+		}
+		return ata::create_conjunction(std::move(conjuncts));
+	}
 	case LOP::LOR: {
 		// init(psi_1 OR psi_2, a) = init(psi_1, a) OR init(psi_2, a)
 		std::vector<std::unique_ptr<Formula<ConstraintSymbolT>>> disjuncts;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(testata PRIVATE automata PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(testata)
 
 add_executable(test_mtl_ata_translation test_mtl_ata_translation.cpp)
-target_link_libraries(test_mtl_ata_translation PRIVATE mtl_ata_translation PRIVATE Catch2::Catch2WithMain spdlog::spdlog)
+target_link_libraries(test_mtl_ata_translation PRIVATE mtl_ata_translation Catch2::Catch2WithMain spdlog::spdlog)
 catch_discover_tests(test_mtl_ata_translation)
 
 add_executable(test_synchronous_product test_synchronous_product.cpp test_synchronous_product_print.cpp)

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -416,4 +416,19 @@ TEST_CASE("Translate an MTL formula with three disjuncts", "[translator]")
 	CHECK(ata.accepts_word({{"c", 0}}));
 }
 
+TEST_CASE("Translate an MTL formula with three conjuncts", "[translator]")
+{
+	const AP   a{"a"};
+	const AP   b{"b"};
+	const AP   c{"c"};
+	const AP   d{"d"};
+	const auto ata =
+	  mtl_ata_translation::translate(MTLFormula<std::string>::create_conjunction({!a, !b, !c}),
+	                                 {a, b, c, d});
+	CHECK(!ata.accepts_word({{"a", 0}}));
+	CHECK(!ata.accepts_word({{"b", 0}}));
+	CHECK(!ata.accepts_word({{"c", 0}}));
+	CHECK(ata.accepts_word({{"d", 0}}));
+}
+
 } // namespace

--- a/test/test_mtl_ata_translation.cpp
+++ b/test/test_mtl_ata_translation.cpp
@@ -6,8 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
-
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 
 #include "mtl/MTLFormula.h"
@@ -407,6 +405,15 @@ TEST_CASE("MTL ATA sink location", "[translator][sink]")
 		// Thus, we should end up in the sink location.
 		CHECK(runs[0][2].second == Configuration{{sink, 0}});
 	}
+}
+
+TEST_CASE("Translate an MTL formula with three disjuncts", "[translator]")
+{
+	const auto ata = mtl_ata_translation::translate(
+	  MTLFormula<std::string>::create_disjunction({AP{"a"}, AP{"b"}, AP{"c"}}));
+	CHECK(ata.accepts_word({{"a", 0}}));
+	CHECK(ata.accepts_word({{"b", 0}}));
+	CHECK(ata.accepts_word({{"c", 0}}));
 }
 
 } // namespace


### PR DESCRIPTION
We made the incorrect assumption that an MTL conjunction (disjunction) always has exactly two conjuncts (disjuncts). However, it may contain any number of subformulas (the subformulas are stored in a vector), which resulted in incorrect translations. In particular, we would only consider the first and last conjunct (disjunct) and ignore the rest.

Fix this by translating the MTLFormula by recursively creating conjunctions (disjunctions) until we have reached a single subformula. This means that the ATA conjunction (disjunction) still only consists of exactly two subformulas, but these are then again conjunctions (disjunctions) if we are translating a formula with more than two subformulas.

We may in the future decide to also have an arbitrary number of subformulas in ATA conjunctions (disjunctions).
For now, keep the ATA formula structure as is and just go with nested conjunctions/disjunctions.

This is backport of #153. See #152 for the original bug.