### PR TITLE
benchmarks: measure time in seconds, not nanoseconds

### DIFF
--- a/test/benchmark_conveyor_belt.cpp
+++ b/test/benchmark_conveyor_belt.cpp
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #include "automata/automata.h"
 #include "automata/ta.h"
 #include "automata/ta_product.h"
@@ -152,19 +151,23 @@ BM_ConveyorBelt(benchmark::State &state, bool weighted = true, bool multi_thread
 BENCHMARK_CAPTURE(BM_ConveyorBelt, single_heuristic, false)
   ->DenseRange(0, 5, 1)
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 BENCHMARK_CAPTURE(BM_ConveyorBelt, single_heuristic_single_thread, false, false)
   ->DenseRange(0, 5, 1)
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 // Single-threaded with weighted heuristics.
 BENCHMARK_CAPTURE(BM_ConveyorBelt, weighted_single_thread, true, false)
   ->Args({16, 4, 1})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 BENCHMARK_CAPTURE(BM_ConveyorBelt, weighted, true)
   ->ArgsProduct({benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateDenseRange(0, 2, 1)})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();

--- a/test/benchmark_railroad.cpp
+++ b/test/benchmark_railroad.cpp
@@ -149,16 +149,19 @@ BM_Railroad(benchmark::State &state, Mode mode, bool multi_threaded = true)
 BENCHMARK_CAPTURE(BM_Railroad, single_heuristic, Mode::SIMPLE)
   ->DenseRange(0, 5, 1)
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 // Single-threaded.
 BENCHMARK_CAPTURE(BM_Railroad, single_heuristic_single_thread, Mode::SIMPLE, false)
   ->DenseRange(0, 5, 1)
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 // Single-threaded with weighted heuristics.
 BENCHMARK_CAPTURE(BM_Railroad, weighted_single_thread, Mode::WEIGHTED, false)
   ->Args({16, 4, 1})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 // Weighted heuristics.
 BENCHMARK_CAPTURE(BM_Railroad, weighted, Mode::WEIGHTED)
@@ -166,15 +169,18 @@ BENCHMARK_CAPTURE(BM_Railroad, weighted, Mode::WEIGHTED)
                  benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateDenseRange(0, 2, 1)})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 // Different distances
 BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
   ->ArgsProduct({benchmark::CreateRange(1, 8, 2), benchmark::CreateRange(1, 8, 2), {0}})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 BENCHMARK_CAPTURE(BM_Railroad, scaled, Mode::SCALED)
   ->Args({1, 1, 1})
   ->Args({2, 1, 1})
   ->Args({2, 2, 2})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();

--- a/test/benchmark_robot.cpp
+++ b/test/benchmark_robot.cpp
@@ -167,15 +167,18 @@ BM_Robot(benchmark::State &state, bool weighted = true, bool multi_threaded = tr
 BENCHMARK_CAPTURE(BM_Robot, single_heuristic, false)
   ->DenseRange(0, 5, 1)
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 BENCHMARK_CAPTURE(BM_Robot, single_heuristic_single_thread, false, false)
   ->DenseRange(0, 5, 1)
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 // Single-threaded with weighted heuristics.
 BENCHMARK_CAPTURE(BM_Robot, weighted_single_thread, true, false)
   ->Args({16, 4, 1})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 
 #ifdef BUILD_LARGE_BENCHMARKS
@@ -184,5 +187,6 @@ BENCHMARK_CAPTURE(BM_Robot, weighted, true)
                  benchmark::CreateRange(1, 16, 2),
                  benchmark::CreateDenseRange(0, 2, 1)})
   ->MeasureProcessCPUTime()
+  ->Unit(benchmark::kSecond)
   ->UseRealTime();
 #endif


### PR DESCRIPTION
Our benchmarks are large enough that measurements in nanoseconds do not
convey additional information and are much harder to read. Switch to
seconds for all benchmarks.

This is a backport of #155.