### PR TITLE
Provide a clock for each Golog action and check action durations

### DIFF
--- a/src/gocos/golog_adapter.cpp
+++ b/src/gocos/golog_adapter.cpp
@@ -37,4 +37,15 @@ operator<(const GologLocation &first, const GologLocation &second)
 	       < second.history->special_semantics().get_managed_term();
 }
 
+namespace details {
+std::map<std::string, float>
+get_clock_values(const ClockSetValuation &clock_valuations)
+{
+	std::map<std::string, float> res;
+	for (const auto &clock : clock_valuations) {
+		res[clock.first] = clock.second.get_valuation();
+	}
+	return res;
+}
+} // namespace details
 } // namespace tacos::search

--- a/src/gocos/golog_adapter.cpp
+++ b/src/gocos/golog_adapter.cpp
@@ -38,10 +38,10 @@ operator<(const GologLocation &first, const GologLocation &second)
 }
 
 namespace details {
-std::map<std::string, float>
+std::map<std::string, double>
 get_clock_values(const ClockSetValuation &clock_valuations)
 {
-	std::map<std::string, float> res;
+	std::map<std::string, double> res;
 	for (const auto &clock : clock_valuations) {
 		res[clock.first] = clock.second.get_valuation();
 	}

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -7,7 +7,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #include "gocos/golog_program.h"
 
 #include "gocos/golog_symbols.h"
@@ -27,7 +26,7 @@ namespace tacos::search {
 
 bool GologProgram::initialized = false;
 
-GologProgram::GologProgram(const std::string &          program,
+GologProgram::GologProgram(const std::string           &program,
                            const std::set<std::string> &relevant_fluent_symbols)
 {
 	if (initialized) {

--- a/src/gocos/include/gocos/golog_adapter.h
+++ b/src/gocos/include/gocos/golog_adapter.h
@@ -74,6 +74,10 @@ private:
 /** Print a golog location to an ostream. */
 std::ostream &operator<<(std::ostream &os, const GologLocation &);
 
+namespace details {
+std::map<std::string, float> get_clock_values(const ClockSetValuation &clock_valuations);
+} // namespace details
+
 } // namespace tacos::search
 
 #include "golog_adapter.hpp"

--- a/src/gocos/include/gocos/golog_adapter.h
+++ b/src/gocos/include/gocos/golog_adapter.h
@@ -75,7 +75,7 @@ private:
 std::ostream &operator<<(std::ostream &os, const GologLocation &);
 
 namespace details {
-std::map<std::string, float> get_clock_values(const ClockSetValuation &clock_valuations);
+std::map<std::string, double> get_clock_values(const ClockSetValuation &clock_valuations);
 } // namespace details
 
 } // namespace tacos::search

--- a/src/gocos/include/gocos/golog_adapter.hpp
+++ b/src/gocos/include/gocos/golog_adapter.hpp
@@ -52,7 +52,8 @@ operator()(
 			const std::string action         = "ctl_terminate";
 			const auto        ata_successors = [&]() {
         if constexpr (use_location_constraints) {
-          return ata.make_symbol_step(ab_configuration.second, std::set<std::string>{"terminated"});
+          return ata.make_symbol_step(ab_configuration.second,
+                                      std::set<std::string>{"terminated(ctl)"});
         } else {
           return ata.make_symbol_step(ab_configuration.second, action);
         }
@@ -76,7 +77,8 @@ operator()(
 			// const auto        ata_successors = ata.make_symbol_step(ab_configuration.second, action);
 			const auto ata_successors = [&]() {
 				if constexpr (use_location_constraints) {
-					return ata.make_symbol_step(ab_configuration.second, std::set<std::string>{"terminated"});
+					return ata.make_symbol_step(ab_configuration.second,
+					                            std::set<std::string>{"terminated(env)"});
 				} else {
 					return ata.make_symbol_step(ab_configuration.second, action);
 				}

--- a/src/gocos/include/gocos/golog_adapter.hpp
+++ b/src/gocos/include/gocos/golog_adapter.hpp
@@ -41,8 +41,14 @@ operator()(
 {
 	std::multimap<std::string, CanonicalABWord<GologLocation, std::string>> successors;
 	const auto &[remaining_program, history] = ab_configuration.first.location;
-	auto golog_successors = program.get_semantics().trans_all(*history, remaining_program.get());
+	auto golog_successors =
+	  program.get_semantics().trans_all(*history,
+	                                    remaining_program.get(),
+	                                    details::get_clock_values(
+	                                      ab_configuration.first.clock_valuations));
 	// Add terminate actions if we are at the max region index.
+	// TODO We do not always reach this branch because we do not always get a time successor for this
+	// increment.
 	if (increment == 2 * K + 1) {
 		// Only add the ctl terminate action if there is at least one env action.
 		if (std::any_of(begin(golog_successors), end(golog_successors), [this](const auto &successor) {
@@ -60,6 +66,9 @@ operator()(
 			}();
 			for (auto &ata_successor : ata_successors) {
 				auto clock_valuations = ab_configuration.first.clock_valuations;
+				if (clock_valuations.size() > 1) {
+					clock_valuations.erase("golog");
+				}
 				successors.insert(std::make_pair(
 				  action,
 				  get_canonical_word(GologConfiguration{{program.get_empty_program(), history},
@@ -85,6 +94,9 @@ operator()(
 			}();
 			for (auto &ata_successor : ata_successors) {
 				auto clock_valuations = ab_configuration.first.clock_valuations;
+				if (clock_valuations.size() > 1) {
+					clock_valuations.erase("golog");
+				}
 				successors.insert(std::make_pair(
 				  action,
 				  get_canonical_word(GologConfiguration{{program.get_empty_program(), history},
@@ -97,17 +109,24 @@ operator()(
 	for (const auto &golog_successor : golog_successors) {
 		const auto &[plan, program_suffix, new_history] = golog_successor;
 		const std::string action                        = plan->elements().front().instruction().str();
-		const auto        ata_successors                = [&]() {
-      if constexpr (use_location_constraints) {
-        return ata.make_symbol_step(ab_configuration.second,
-                                    program.get_satisfied_fluents(*std::get<2>(golog_successor)));
-      } else {
-        return ata.make_symbol_step(ab_configuration.second, action);
-      }
+		auto              clock_valuations              = ab_configuration.first.clock_valuations;
+		if (action.substr(0, 6) == "start(") {
+			const auto prim_action = action.substr(6, action.size() - 2 - 5);
+			// Reset to the clock to 0 if it already exists and otherwise insert a new clock.
+			clock_valuations[prim_action].reset();
+		}
+		if (clock_valuations.size() > 1) {
+			clock_valuations.erase("golog");
+		}
+		const auto ata_successors = [&]() {
+			if constexpr (use_location_constraints) {
+				return ata.make_symbol_step(ab_configuration.second,
+				                            program.get_satisfied_fluents(*std::get<2>(golog_successor)));
+			} else {
+				return ata.make_symbol_step(ab_configuration.second, action);
+			}
 		}();
 		for (const auto &ata_successor : ata_successors) {
-			auto clock_valuations           = ab_configuration.first.clock_valuations;
-			clock_valuations["golog"]       = 0;
 			[[maybe_unused]] auto successor = successors.insert(std::make_pair(
 			  action,
 			  get_canonical_word(GologConfiguration{{program_suffix, new_history}, clock_valuations},

--- a/src/search/include/search/adapter.h
+++ b/src/search/include/search/adapter.h
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #pragma once
 
 #include "search/canonical_word.h"

--- a/test/test_golog_search.cpp
+++ b/test/test_golog_search.cpp
@@ -275,7 +275,7 @@ TEST_CASE("Search on fluent constraints", "[golog][search]")
 {
 	const auto spec =
 	  globally(!MTLFormula<std::string>{logic::AtomicProposition<std::string>{"visited(wien)"}})
-	  || finally(MTLFormula<std::string>{logic::AtomicProposition<std::string>{"terminated"}});
+	  || finally(MTLFormula<std::string>{logic::AtomicProposition<std::string>{"terminated(env)"}});
 	auto ata = mtl_ata_translation::translate<std::string, std::set<std::string>, true>(spec);
 	// TODO refactor so we do not need unwrap anymore
 	auto unwrap = [](std::set<AtomicProposition<std::set<std::string>>> input) {
@@ -289,14 +289,16 @@ TEST_CASE("Search on fluent constraints", "[golog][search]")
 	};
 
 	GologProgram program(R"(
+    symbol domain actor = { ctl, env }
     symbol domain location = { aachen, wien }
     bool fluent visited(symbol l) {
       initially:
         (l) = false;
     }
-    bool fluent terminated() {
+    bool fluent terminated(symbol a) {
       initially:
-        () = false;
+        (ctl) = false;
+        (env) = false;
     }
     action visit(symbol l) {
       effect:

--- a/test/test_golog_words.cpp
+++ b/test/test_golog_words.cpp
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #include "gocos/golog_adapter.h"
 #include "gocos/golog_program.h"
 #include "mtl/MTLFormula.h"
@@ -52,6 +51,8 @@ TEST_CASE("Golog successors", "[golog]")
 	CHECK(next_words.find("start(say())") != std::end(next_words));
 	CHECK(next_words.begin()->first == "start(say())");
 	CHECK(next_words.begin()->second.size() == 1);
+	// 1 for the plant configuration, 1 for the ATA configuration
+	CHECK(next_words.begin()->second.begin()->size() == 2);
 	for (const auto &ab_symbol : next_words.begin()->second.front()) {
 		using GologSymbol = search::PlantRegionState<search::GologLocation>;
 		if (std::holds_alternative<GologSymbol>(ab_symbol)) {
@@ -59,7 +60,7 @@ TEST_CASE("Golog successors", "[golog]")
 			CHECK(golog_symbol.location.history->special_semantics().as_transitions().size() == 1);
 			CHECK(gologpp::ReadylogContext::instance().to_string(*golog_symbol.location.remaining_program)
 			      == "[end('gpp~say')]");
-			CHECK(golog_symbol.clock == "golog");
+			CHECK(golog_symbol.clock == "say()");
 			CHECK(golog_symbol.region_index == 0);
 		} else {
 			REQUIRE(std::holds_alternative<search::ATARegionState<std::string>>(ab_symbol));


### PR DESCRIPTION
Whenever a start action occurs, insert a clock and reset it to 0.
Whenever an end action occurs, compare the clock value against the
action duration. More precisely, pass the current clock value to gologpp
so it only generates a successor if the duration constraint is
satisfied.

This allows to model some kind of timing constraint in golog without
introducing full clock constraints.