### PR TITLE
Compare Golog locations based on fluents

### DIFF
--- a/src/gocos/golog_adapter.cpp
+++ b/src/gocos/golog_adapter.cpp
@@ -33,8 +33,7 @@ operator<(const GologLocation &first, const GologLocation &second)
 	if (*second.remaining_program < *first.remaining_program) {
 		return false;
 	}
-	return first.program->get_satisfied_fluents(*first.history)
-	       < second.program->get_satisfied_fluents(*second.history);
+	return first.satisfied_fluents < second.satisfied_fluents;
 }
 
 namespace details {

--- a/src/gocos/golog_adapter.cpp
+++ b/src/gocos/golog_adapter.cpp
@@ -8,6 +8,9 @@
 
 #include "gocos/golog_adapter.h"
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 namespace tacos::search {
 
 std::ostream &
@@ -20,7 +23,7 @@ operator<<(std::ostream &os, const GologLocation &location)
 		os << "[]";
 	}
 	os << ", ";
-	os << location.history->special_semantics() << ")";
+	fmt::print(os, "[{}]", fmt::join(location.satisfied_fluents, ", "));
 	return os;
 }
 

--- a/src/gocos/golog_adapter.cpp
+++ b/src/gocos/golog_adapter.cpp
@@ -33,8 +33,8 @@ operator<(const GologLocation &first, const GologLocation &second)
 	if (*second.remaining_program < *first.remaining_program) {
 		return false;
 	}
-	return first.history->special_semantics().get_managed_term()
-	       < second.history->special_semantics().get_managed_term();
+	return first.program->get_satisfied_fluents(*first.history)
+	       < second.program->get_satisfied_fluents(*second.history);
 }
 
 namespace details {

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -98,9 +98,9 @@ std::set<std::string>
 GologProgram::get_satisfied_fluents(const gologpp::History &history) const
 {
 	std::set<std::string> satisfied_fluents;
-	for (const auto &global : relevant_fluents) {
-		if (static_cast<bool>(global->semantics().evaluate({}, history))) {
-			satisfied_fluents.insert(global->to_string(""));
+	for (const auto &[name, fluent] : relevant_fluents) {
+		if (static_cast<bool>(fluent->semantics().evaluate({}, history))) {
+			satisfied_fluents.insert(name);
 		}
 	}
 	return satisfied_fluents;
@@ -121,7 +121,7 @@ GologProgram::populate_relevant_fluents(const std::set<std::string> &relevant_fl
 		}
 		auto ref = fluent->make_ref(params);
 		ref->attach_semantics(*semantics);
-		relevant_fluents.emplace(ref);
+		relevant_fluents.emplace(fluent_symbol, ref);
 	}
 }
 

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -10,6 +10,9 @@
 #include "gocos/golog_program.h"
 
 #include "gocos/golog_symbols.h"
+#include "model/types.h"
+
+#include <spdlog/spdlog.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
@@ -52,7 +55,7 @@ GologProgram::GologProgram(const std::string           &program,
 	empty_program.reset(new gologpp::ManagedTerm(gologpp::make_ec_list({})));
 	gologpp::global_scope().implement_globals(*semantics, gologpp::ReadylogContext::instance());
 
-	populate_relevant_fluents(relevant_fluent_symbols);
+	populate_fluents(relevant_fluent_symbols);
 }
 
 GologProgram::~GologProgram()
@@ -73,7 +76,7 @@ GologProgram::teardown()
 GologLocation
 GologProgram::get_initial_location() const
 {
-	GologLocation location{get_satisfied_fluents(*get_empty_history()),
+	GologLocation location{get_all_satisfied_fluents(*get_empty_history()),
 	                       std::make_shared<gologpp::ManagedTerm>(main->semantics().plterm()),
 	                       std::make_shared<gologpp::History>()};
 	location.history->attach_semantics(*semantics);
@@ -95,39 +98,69 @@ GologProgram::is_accepting_configuration(const GologConfiguration &configuration
 }
 
 std::set<std::string>
-GologProgram::get_satisfied_fluents(const gologpp::History &history) const
+GologProgram::get_satisfied_fluents(
+  const gologpp::History                                             &history,
+  const std::map<std::string, gologpp::Reference<gologpp::Fluent> *> &fluents) const
 {
 	std::set<std::string> satisfied_fluents;
-	for (const auto &[name, fluent] : relevant_fluents) {
-		if (fluent) {
-			if (static_cast<bool>(fluent->semantics().evaluate({}, history))) {
-				satisfied_fluents.insert(name);
-			}
+	for (const auto &[name, fluent] : fluents) {
+		if (static_cast<bool>(fluent->semantics().evaluate({}, history))) {
+			satisfied_fluents.insert(name);
 		}
 	}
 	return satisfied_fluents;
 }
 
-void
-GologProgram::populate_relevant_fluents(const std::set<std::string> &relevant_fluent_symbols)
+std::set<std::string>
+GologProgram::get_relevant_satisfied_fluents(const gologpp::History &history) const
 {
-	for (const auto &fluent_symbol : relevant_fluent_symbols) {
-		const auto [name, args] = split_symbol(fluent_symbol);
-		if (name == "occ") {
-			relevant_fluents.emplace(fluent_symbol, nullptr);
-			continue;
+	return get_satisfied_fluents(history, relevant_fluents);
+}
+
+std::set<std::string>
+GologProgram::get_all_satisfied_fluents(const gologpp::History &history) const
+{
+	return get_satisfied_fluents(history, all_fluents);
+}
+
+void
+GologProgram::populate_fluents(const std::set<std::string> &relevant_fluent_symbols)
+{
+	for (const auto &global : gologpp::global_scope().globals()) {
+		const auto fluent = gologpp::global_scope().lookup_global<gologpp::Fluent>(global->name());
+		if (fluent) {
+			if (!fluent->type().is<gologpp::BoolType>()) {
+				SPDLOG_WARN("Fluent {} is not of type bool, ignoring! Make sure this fluent is irrelevant.",
+				            fluent->name());
+				continue;
+			}
+			std::vector<std::vector<gologpp::Expression *>> possible_arg_vectors = {{}};
+			for (auto i = 0; i < fluent->arity(); i++) {
+				std::vector<std::vector<gologpp::Expression *>> new_possible_arg_vectors;
+				for (const auto &[_, domain] : *gologpp::global_scope().get_domains()) {
+					if (fluent->parameter(i)->type().name() == domain->type().name()) {
+						for (const auto &arg : domain->elements()) {
+							for (const auto &args : possible_arg_vectors) {
+								auto new_args = args;
+								new_args.push_back(arg.get());
+								new_possible_arg_vectors.push_back(new_args);
+							}
+						}
+					}
+				}
+				possible_arg_vectors = new_possible_arg_vectors;
+			}
+			for (const auto &args : possible_arg_vectors) {
+				auto ref = fluent->make_ref(args);
+				ref->attach_semantics(*semantics);
+				SPDLOG_DEBUG("Tracking fluent: {}", ref->str());
+				all_fluents.emplace(ref->str(), ref);
+				if (relevant_fluent_symbols.find(ref->str()) != std::end(relevant_fluent_symbols)) {
+					SPDLOG_DEBUG("Tracking relevant fluent: {}", ref->str());
+					relevant_fluents.emplace(ref->str(), ref);
+				}
+			}
 		}
-		const auto fluent = gologpp::global_scope().lookup_global<gologpp::Fluent>(name);
-		if (!fluent) {
-			throw std::invalid_argument(fmt::format("Fluent {} is not known in the Golog program", name));
-		}
-		std::vector<gologpp::Expression *> params;
-		for (const auto &arg : args) {
-			params.push_back(gologpp::global_scope().get_symbol(arg));
-		}
-		auto ref = fluent->make_ref(params);
-		ref->attach_semantics(*semantics);
-		relevant_fluents.emplace(fluent_symbol, ref);
 	}
 }
 

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -73,7 +73,7 @@ GologProgram::teardown()
 GologLocation
 GologProgram::get_initial_location() const
 {
-	GologLocation location{this,
+	GologLocation location{get_satisfied_fluents(*get_empty_history()),
 	                       std::make_shared<gologpp::ManagedTerm>(main->semantics().plterm()),
 	                       std::make_shared<gologpp::History>()};
 	location.history->attach_semantics(*semantics);

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -73,9 +73,9 @@ GologProgram::teardown()
 GologLocation
 GologProgram::get_initial_location() const
 {
-	GologLocation location;
-	location.remaining_program = std::make_shared<gologpp::ManagedTerm>(main->semantics().plterm());
-	location.history.reset(new gologpp::History());
+	GologLocation location{this,
+	                       std::make_shared<gologpp::ManagedTerm>(main->semantics().plterm()),
+	                       std::make_shared<gologpp::History>()};
 	location.history->attach_semantics(*semantics);
 	return location;
 }
@@ -83,10 +83,8 @@ GologProgram::get_initial_location() const
 GologConfiguration
 GologProgram::get_initial_configuration() const
 {
-	GologConfiguration configuration;
-	configuration.location = get_initial_location();
-	configuration.clock_valuations.insert(std::make_pair(std::string{"golog"}, tacos::Clock{}));
-	return configuration;
+	return GologConfiguration{get_initial_location(),
+	                          {std::make_pair(std::string{"golog"}, tacos::Clock{})}};
 }
 
 bool

--- a/src/gocos/golog_program.cpp
+++ b/src/gocos/golog_program.cpp
@@ -99,8 +99,10 @@ GologProgram::get_satisfied_fluents(const gologpp::History &history) const
 {
 	std::set<std::string> satisfied_fluents;
 	for (const auto &[name, fluent] : relevant_fluents) {
-		if (static_cast<bool>(fluent->semantics().evaluate({}, history))) {
-			satisfied_fluents.insert(name);
+		if (fluent) {
+			if (static_cast<bool>(fluent->semantics().evaluate({}, history))) {
+				satisfied_fluents.insert(name);
+			}
 		}
 	}
 	return satisfied_fluents;
@@ -111,7 +113,11 @@ GologProgram::populate_relevant_fluents(const std::set<std::string> &relevant_fl
 {
 	for (const auto &fluent_symbol : relevant_fluent_symbols) {
 		const auto [name, args] = split_symbol(fluent_symbol);
-		const auto fluent       = gologpp::global_scope().lookup_global<gologpp::Fluent>(name);
+		if (name == "occ") {
+			relevant_fluents.emplace(fluent_symbol, nullptr);
+			continue;
+		}
+		const auto fluent = gologpp::global_scope().lookup_global<gologpp::Fluent>(name);
 		if (!fluent) {
 			throw std::invalid_argument(fmt::format("Fluent {} is not known in the Golog program", name));
 		}

--- a/src/gocos/golog_symbols.cpp
+++ b/src/gocos/golog_symbols.cpp
@@ -16,7 +16,7 @@ namespace tacos::search {
 std::pair<std::string, std::vector<std::string>>
 split_symbol(const std::string &symbol)
 {
-	const std::regex name_regex("\\s*(\\w+)\\s*(?:\\(\\s*([^)]*)\\s*\\))?\\s*");
+	const std::regex name_regex("\\s*(\\w+)\\s*(?:\\(\\s*(.*?)\\s*\\))?\\s*");
 	const std::regex split_args_regex("[^\\s,]+");
 	std::smatch      matches;
 	std::regex_match(symbol, matches, name_regex);

--- a/src/gocos/include/gocos/golog_adapter.hpp
+++ b/src/gocos/include/gocos/golog_adapter.hpp
@@ -58,22 +58,21 @@ operator()(
 		if (clock_valuations.size() > 1) {
 			clock_valuations.erase("golog");
 		}
-		const auto ata_successors = [&]() {
-			if constexpr (use_location_constraints) {
-				return ata.make_symbol_step(ab_configuration.second,
-				                            program.get_satisfied_fluents(*std::get<2>(golog_successor)));
-			} else {
-				return ata.make_symbol_step(ab_configuration.second, action);
-			}
+		const auto satisfied_fluents = program.get_satisfied_fluents(*new_history);
+		const auto ata_successors    = [&]() {
+      if constexpr (use_location_constraints) {
+        return ata.make_symbol_step(ab_configuration.second, satisfied_fluents);
+      } else {
+        return ata.make_symbol_step(ab_configuration.second, action);
+      }
 		}();
 		for (const auto &ata_successor : ata_successors) {
 			[[maybe_unused]] auto successor = successors.insert(std::make_pair(
 			  action,
-			  get_canonical_word(
-			    GologConfiguration{{program.get_satisfied_fluents(*history), program_suffix, new_history},
-			                       clock_valuations},
-			    ata_successor,
-			    K)));
+			  get_canonical_word(GologConfiguration{{satisfied_fluents, program_suffix, new_history},
+			                                        clock_valuations},
+			                     ata_successor,
+			                     K)));
 			SPDLOG_TRACE("{}, {}): Getting {} with symbol {}",
 			             ab_configuration.first,
 			             ab_configuration.second,

--- a/src/gocos/include/gocos/golog_adapter.hpp
+++ b/src/gocos/include/gocos/golog_adapter.hpp
@@ -40,7 +40,7 @@ operator()(
   const RegionIndex                                                   K)
 {
 	std::multimap<std::string, CanonicalABWord<GologLocation, std::string>> successors;
-	const auto &[remaining_program, history] = ab_configuration.first.location;
+	const auto &[_, remaining_program, history] = ab_configuration.first.location;
 	auto golog_successors =
 	  program.get_semantics().trans_all(*history,
 	                                    remaining_program.get(),
@@ -69,7 +69,8 @@ operator()(
 		for (const auto &ata_successor : ata_successors) {
 			[[maybe_unused]] auto successor = successors.insert(std::make_pair(
 			  action,
-			  get_canonical_word(GologConfiguration{{program_suffix, new_history}, clock_valuations},
+			  get_canonical_word(GologConfiguration{{&program, program_suffix, new_history},
+			                                        clock_valuations},
 			                     ata_successor,
 			                     K)));
 			SPDLOG_TRACE("{}, {}): Getting {} with symbol {}",

--- a/src/gocos/include/gocos/golog_adapter.hpp
+++ b/src/gocos/include/gocos/golog_adapter.hpp
@@ -69,10 +69,11 @@ operator()(
 		for (const auto &ata_successor : ata_successors) {
 			[[maybe_unused]] auto successor = successors.insert(std::make_pair(
 			  action,
-			  get_canonical_word(GologConfiguration{{&program, program_suffix, new_history},
-			                                        clock_valuations},
-			                     ata_successor,
-			                     K)));
+			  get_canonical_word(
+			    GologConfiguration{{program.get_satisfied_fluents(*history), program_suffix, new_history},
+			                       clock_valuations},
+			    ata_successor,
+			    K)));
 			SPDLOG_TRACE("{}, {}): Getting {} with symbol {}",
 			             ab_configuration.first,
 			             ab_configuration.second,

--- a/src/gocos/include/gocos/golog_program.h
+++ b/src/gocos/include/gocos/golog_program.h
@@ -26,12 +26,16 @@
 
 namespace tacos::search {
 
+class GologProgram;
+
 /** The location of a golog program.
  * This represents the current state of a program execution and consists of a gologpp term for the
  * remaining program, as well as a gologpp history.
  */
 struct GologLocation
 {
+	/** A pointer to the complete program. Its lifetime must surpass  this object's lifetime. */
+	const GologProgram *program;
 	/** The program yet to be executed. */
 	gologpp::shared_ptr<gologpp::ManagedTerm> remaining_program;
 	/** A history of already executed actions. */

--- a/src/gocos/include/gocos/golog_program.h
+++ b/src/gocos/include/gocos/golog_program.h
@@ -34,8 +34,7 @@ class GologProgram;
  */
 struct GologLocation
 {
-	/** A pointer to the complete program. Its lifetime must surpass  this object's lifetime. */
-	const GologProgram *program;
+	std::set<std::string> satisfied_fluents;
 	/** The program yet to be executed. */
 	gologpp::shared_ptr<gologpp::ManagedTerm> remaining_program;
 	/** A history of already executed actions. */

--- a/src/gocos/include/gocos/golog_program.h
+++ b/src/gocos/include/gocos/golog_program.h
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #pragma once
 
 #include <memory>
@@ -61,7 +60,7 @@ public:
 	/** Construct a program from a program string.
 	 * @param program A golog program as string.
 	 */
-	GologProgram(const std::string &          program,
+	GologProgram(const std::string           &program,
 	             const std::set<std::string> &relevant_fluent_symbols = {});
 
 	/** Clean up the Golog program and release global resources. */
@@ -102,8 +101,11 @@ public:
 	/** Check if a program is accepting, i.e., terminates, in the given configuration. */
 	bool is_accepting_configuration(const GologConfiguration &configuration) const;
 
-	/** Get the satisfied fluents at the point of the given history. */
-	std::set<std::string> get_satisfied_fluents(const gologpp::History &history) const;
+	/** Get the satisfied relevant fluents at the point of the given history. */
+	std::set<std::string> get_relevant_satisfied_fluents(const gologpp::History &history) const;
+
+	/** Get the satisfied relevant fluents at the point of the given history. */
+	std::set<std::string> get_all_satisfied_fluents(const gologpp::History &history) const;
 
 	/** Check if a given fluent is relevant. */
 	bool
@@ -113,18 +115,22 @@ public:
 	}
 
 private:
-	void teardown();
-	void populate_relevant_fluents(const std::set<std::string> &relevant_fluent_symbols);
+	void                  teardown();
+	void                  populate_fluents(const std::set<std::string> &relevant_fluent_symbols);
+	std::set<std::string> get_satisfied_fluents(
+	  const gologpp::History                                             &history,
+	  const std::map<std::string, gologpp::Reference<gologpp::Fluent> *> &fluents) const;
 
 	// We can only have one program at a time, because the program accesses the global scope. Thus,
 	// make sure that we do not run two programs simultaneously.
-	static bool                                                                 initialized;
-	std::shared_ptr<gologpp::Procedure>                                         procedure;
-	gologpp::Instruction *                                                      main;
-	gologpp::SemanticsFactory *                                                 semantics;
-	std::shared_ptr<gologpp::History>                                           empty_history;
-	std::shared_ptr<gologpp::ManagedTerm>                                       empty_program;
-	std::map<std::string, std::unique_ptr<gologpp::Reference<gologpp::Fluent>>> relevant_fluents;
+	static bool                                                  initialized;
+	std::shared_ptr<gologpp::Procedure>                          procedure;
+	gologpp::Instruction                                        *main;
+	gologpp::SemanticsFactory                                   *semantics;
+	std::shared_ptr<gologpp::History>                            empty_history;
+	std::shared_ptr<gologpp::ManagedTerm>                        empty_program;
+	std::map<std::string, gologpp::Reference<gologpp::Fluent> *> all_fluents;
+	std::map<std::string, gologpp::Reference<gologpp::Fluent> *> relevant_fluents;
 };
 
 } // namespace tacos::search

--- a/src/gocos/include/gocos/golog_program.h
+++ b/src/gocos/include/gocos/golog_program.h
@@ -111,13 +111,13 @@ private:
 
 	// We can only have one program at a time, because the program accesses the global scope. Thus,
 	// make sure that we do not run two programs simultaneously.
-	static bool                                                    initialized;
-	std::shared_ptr<gologpp::Procedure>                            procedure;
-	gologpp::Instruction *                                         main;
-	gologpp::SemanticsFactory *                                    semantics;
-	std::shared_ptr<gologpp::History>                              empty_history;
-	std::shared_ptr<gologpp::ManagedTerm>                          empty_program;
-	std::set<std::unique_ptr<gologpp::Reference<gologpp::Fluent>>> relevant_fluents;
+	static bool                                                                 initialized;
+	std::shared_ptr<gologpp::Procedure>                                         procedure;
+	gologpp::Instruction *                                                      main;
+	gologpp::SemanticsFactory *                                                 semantics;
+	std::shared_ptr<gologpp::History>                                           empty_history;
+	std::shared_ptr<gologpp::ManagedTerm>                                       empty_program;
+	std::map<std::string, std::unique_ptr<gologpp::Reference<gologpp::Fluent>>> relevant_fluents;
 };
 
 } // namespace tacos::search

--- a/src/gocos/include/gocos/golog_program.h
+++ b/src/gocos/include/gocos/golog_program.h
@@ -105,6 +105,13 @@ public:
 	/** Get the satisfied fluents at the point of the given history. */
 	std::set<std::string> get_satisfied_fluents(const gologpp::History &history) const;
 
+	/** Check if a given fluent is relevant. */
+	bool
+	is_relevant_fluent(const std::string &fluent) const
+	{
+		return relevant_fluents.find(fluent) != relevant_fluents.end();
+	}
+
 private:
 	void teardown();
 	void populate_relevant_fluents(const std::set<std::string> &relevant_fluent_symbols);

--- a/test/test_golog_search.cpp
+++ b/test/test_golog_search.cpp
@@ -62,9 +62,9 @@ TEST_CASE("Get the currently satisfied Golog fluents", "[golog]")
     }
     procedure main() { visit(aachen); visit(wien); }
   )",
-	                     {"visited(aachen)", "visited(wien)"});
+	                     {"visited(wien)"});
 	auto         history = program.get_empty_history();
-	CHECK(program.get_satisfied_fluents(*history) == std::set<std::string>{});
+	CHECK(program.get_all_satisfied_fluents(*history) == std::set<std::string>{});
 	// start visit(aachen)
 	auto successor = program.get_semantics().trans_all(*history)[0];
 	auto remaining = std::get<1>(successor);
@@ -74,7 +74,9 @@ TEST_CASE("Get the currently satisfied Golog fluents", "[golog]")
 	  program.get_semantics().trans_all(*history, remaining.get(), {{"visit(aachen)", 0}})[0];
 	remaining = std::get<1>(successor);
 	history   = std::get<2>(successor);
-	CHECK(program.get_satisfied_fluents(*history) == std::set<std::string>{"visited(aachen)"});
+	CAPTURE(history->special_semantics());
+	CHECK(program.get_all_satisfied_fluents(*history) == std::set<std::string>{"visited(aachen)"});
+	CHECK(program.get_relevant_satisfied_fluents(*history) == std::set<std::string>{});
 	// start visit(wien)
 	successor = program.get_semantics().trans_all(*history, remaining.get())[0];
 	remaining = std::get<1>(successor);
@@ -85,8 +87,9 @@ TEST_CASE("Get the currently satisfied Golog fluents", "[golog]")
 	                                              {{"visit(aachen)", 0}, {"visit(wien)", 0}})[0];
 	remaining = std::get<1>(successor);
 	history   = std::get<2>(successor);
-	CHECK(program.get_satisfied_fluents(*history)
+	CHECK(program.get_all_satisfied_fluents(*history)
 	      == std::set<std::string>{"visited(aachen)", "visited(wien)"});
+	CHECK(program.get_relevant_satisfied_fluents(*history) == std::set<std::string>{"visited(wien)"});
 }
 
 TEST_CASE("Compare GologLocations", "[golog]")
@@ -95,10 +98,10 @@ TEST_CASE("Compare GologLocations", "[golog]")
     action say() { }
     procedure main() { say(); }
   )");
-	const GologLocation l1{program.get_satisfied_fluents(*program.get_empty_history()),
+	const GologLocation l1{program.get_all_satisfied_fluents(*program.get_empty_history()),
 	                       program.get_empty_program(),
 	                       program.get_empty_history()};
-	const GologLocation l2{program.get_satisfied_fluents(*program.get_empty_history()),
+	const GologLocation l2{program.get_all_satisfied_fluents(*program.get_empty_history()),
 	                       program.get_empty_program(),
 	                       program.get_empty_history()};
 	CHECK(!(l1 < l2));
@@ -121,13 +124,13 @@ TEST_CASE("Check Golog final locations", "[golog]")
   )");
 
 	CHECK(!program.is_accepting_configuration(program.get_initial_configuration()));
-	CHECK(program.is_accepting_configuration(
-	  GologConfiguration{GologLocation{program.get_satisfied_fluents(*program.get_empty_history()),
-	                                   program.get_empty_program(),
-	                                   program.get_empty_history()},
-	                     {}}));
 	CHECK(program.is_accepting_configuration(GologConfiguration{
-	  GologLocation{program.get_satisfied_fluents(*program.get_empty_history()),
+	  GologLocation{program.get_all_satisfied_fluents(*program.get_empty_history()),
+	                program.get_empty_program(),
+	                program.get_empty_history()},
+	  {}}));
+	CHECK(program.is_accepting_configuration(GologConfiguration{
+	  GologLocation{program.get_all_satisfied_fluents(*program.get_empty_history()),
 	                std::make_shared<gologpp::ManagedTerm>(gologpp::make_ec_list({})),
 	                program.get_empty_history()},
 	  {}}));

--- a/test/test_golog_search.cpp
+++ b/test/test_golog_search.cpp
@@ -95,8 +95,8 @@ TEST_CASE("Compare GologLocations", "[golog]")
     action say() { }
     procedure main() { say(); }
   )");
-	const GologLocation l1{program.get_empty_program(), program.get_empty_history()};
-	const GologLocation l2{program.get_empty_program(), program.get_empty_history()};
+	const GologLocation l1{&program, program.get_empty_program(), program.get_empty_history()};
+	const GologLocation l2{&program, program.get_empty_program(), program.get_empty_history()};
 	CHECK(!(l1 < l2));
 	CHECK(!(l2 < l1));
 	const auto i1 = program.get_initial_location();
@@ -117,11 +117,11 @@ TEST_CASE("Check Golog final locations", "[golog]")
   )");
 
 	CHECK(!program.is_accepting_configuration(program.get_initial_configuration()));
-	CHECK(program.is_accepting_configuration(
-	  GologConfiguration{GologLocation{program.get_empty_program(), program.get_empty_history()},
-	                     {}}));
 	CHECK(program.is_accepting_configuration(GologConfiguration{
-	  GologLocation{std::make_shared<gologpp::ManagedTerm>(gologpp::make_ec_list({})),
+	  GologLocation{&program, program.get_empty_program(), program.get_empty_history()}, {}}));
+	CHECK(program.is_accepting_configuration(GologConfiguration{
+	  GologLocation{&program,
+	                std::make_shared<gologpp::ManagedTerm>(gologpp::make_ec_list({})),
 	                program.get_empty_history()},
 	  {}}));
 }

--- a/test/test_golog_search.cpp
+++ b/test/test_golog_search.cpp
@@ -95,8 +95,12 @@ TEST_CASE("Compare GologLocations", "[golog]")
     action say() { }
     procedure main() { say(); }
   )");
-	const GologLocation l1{&program, program.get_empty_program(), program.get_empty_history()};
-	const GologLocation l2{&program, program.get_empty_program(), program.get_empty_history()};
+	const GologLocation l1{program.get_satisfied_fluents(*program.get_empty_history()),
+	                       program.get_empty_program(),
+	                       program.get_empty_history()};
+	const GologLocation l2{program.get_satisfied_fluents(*program.get_empty_history()),
+	                       program.get_empty_program(),
+	                       program.get_empty_history()};
 	CHECK(!(l1 < l2));
 	CHECK(!(l2 < l1));
 	const auto i1 = program.get_initial_location();
@@ -117,10 +121,13 @@ TEST_CASE("Check Golog final locations", "[golog]")
   )");
 
 	CHECK(!program.is_accepting_configuration(program.get_initial_configuration()));
+	CHECK(program.is_accepting_configuration(
+	  GologConfiguration{GologLocation{program.get_satisfied_fluents(*program.get_empty_history()),
+	                                   program.get_empty_program(),
+	                                   program.get_empty_history()},
+	                     {}}));
 	CHECK(program.is_accepting_configuration(GologConfiguration{
-	  GologLocation{&program, program.get_empty_program(), program.get_empty_history()}, {}}));
-	CHECK(program.is_accepting_configuration(GologConfiguration{
-	  GologLocation{&program,
+	  GologLocation{program.get_satisfied_fluents(*program.get_empty_history()),
 	                std::make_shared<gologpp::ManagedTerm>(gologpp::make_ec_list({})),
 	                program.get_empty_history()},
 	  {}}));

--- a/test/test_golog_words.cpp
+++ b/test/test_golog_words.cpp
@@ -85,8 +85,8 @@ TEST_CASE("Golog fluent-based successors", "[golog]")
     }
     procedure main() { say(); }
   )",
-	                     {"said"});
-	const auto   f   = MTLFormula<std::string>{std::string{"said"}};
+	                     {"said()"});
+	const auto   f   = MTLFormula<std::string>{std::string{"said()"}};
 	const auto   ata = mtl_ata_translation::translate<std::string, std::set<std::string>, true>(f);
 	CAPTURE(ata);
 	search::GologConfiguration  golog_configuration = program.get_initial_configuration();
@@ -108,7 +108,7 @@ TEST_CASE("Golog fluent-based successors", "[golog]")
 	REQUIRE(std::holds_alternative<GologSymbol>(ab_symbol));
 	const auto &golog_symbol = std::get<GologSymbol>(ab_symbol);
 	CHECK(golog_symbol.location.history->special_semantics().as_transitions().size() == 1);
-	CHECK(golog_symbol.location.satisfied_fluents == std::set<std::string>{"said"});
+	CHECK(golog_symbol.location.satisfied_fluents == std::set<std::string>{"said()"});
 	CHECK(gologpp::ReadylogContext::instance().to_string(*golog_symbol.location.remaining_program)
 	      == "[end('gpp~say')]");
 	CHECK(golog_symbol.clock == "say()");


### PR DESCRIPTION
Instead of comparing the locations based on the history, use the satisfied fluents. This is necessary because the history always grows, even if we are in a world state that is the same as a previous state.

This also  requires us to distinguish between the fluents that are relevant to check the MTL specification and all fluents that are satisfied. We need to compare based on the latter, because we may be in two different states even if all the fluents relevant for the specification are the same.

Along the way, also add two minor improvements:
* Add a special predicate `occ(action)` that can be used in the specification to check whether a certain action has occurred
* In a state-based setting, directly initialize the ATA configuration with the fluents that are satisfied in the initial situation.