### PR TITLE
Compute time successors for all possible increments of the node

### DIFF
--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -425,8 +425,8 @@ private:
 		  child_classes;
 
 		const auto time_successors = get_time_successors(node->words, K_);
-		for (const auto &[word, successors] : time_successors) {
-			for (const auto &[increment, time_successor] : successors) {
+		for (std::size_t increment = 0; increment < time_successors.size(); ++increment) {
+			for (const auto &time_successor : time_successors[increment]) {
 				auto successors =
 				  get_next_canonical_words<Plant,
 				                           ActionType,

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -420,14 +420,13 @@ private:
 			return {};
 		}
 		assert(node->get_children().empty());
-		// Represent a set of configurations by their reg_a component so we can later partition the
-		// set
 		std::map<std::pair<RegionIndex, ActionType>,
 		         std::set<CanonicalABWord<Location, ConstraintSymbolType>>>
 		  child_classes;
 
-		for (const auto &word : node->words) {
-			for (const auto &[increment, time_successor] : get_time_successors(word, K_)) {
+		const auto time_successors = get_time_successors(node->words, K_);
+		for (const auto &[word, successors] : time_successors) {
+			for (const auto &[increment, time_successor] : successors) {
 				auto successors =
 				  get_next_canonical_words<Plant,
 				                           ActionType,

--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -191,7 +191,7 @@ public:
 	 */
 	TreeSearch(
 	  // const automata::ta::TimedAutomaton<Location, ActionType> *                                ta,
-	  const Plant	                                                                    *ta,
+	  const Plant                                                                      *ta,
 	  automata::ata::AlternatingTimedAutomaton<logic::MTLFormula<ConstraintSymbolType>,
 	                                           logic::AtomicProposition<ATAInputType>> *ata,
 	  std::set<ActionType>                   controller_actions,
@@ -423,8 +423,7 @@ private:
 		// Represent a set of configurations by their reg_a component so we can later partition the
 		// set
 		std::map<std::pair<RegionIndex, ActionType>,
-		         std::map<CanonicalABWord<Location, ConstraintSymbolType>,
-		                  std::set<CanonicalABWord<Location, ConstraintSymbolType>>>>
+		         std::set<CanonicalABWord<Location, ConstraintSymbolType>>>
 		  child_classes;
 
 		for (const auto &word : node->words) {
@@ -437,13 +436,12 @@ private:
 				                           use_set_semantics>(controller_actions_, environment_actions_)(
 				    *ta_, *ata_, get_candidate(time_successor), increment, K_);
 				for (const auto &[symbol, successor] : successors) {
-					const auto word_reg = reg_a(successor);
 					assert(
 					  std::find(std::begin(controller_actions_), std::end(controller_actions_), symbol)
 					    != std::end(controller_actions_)
 					  || std::find(std::begin(environment_actions_), std::end(environment_actions_), symbol)
 					       != std::end(environment_actions_));
-					child_classes[std::make_pair(increment, symbol)][word_reg].insert(successor);
+					child_classes[std::make_pair(increment, symbol)].insert(successor);
 				}
 			}
 		}
@@ -454,17 +452,18 @@ private:
 		// the same reg_a class.
 		{
 			std::lock_guard lock{nodes_mutex_};
-			for (const auto &[timed_action, word_map] : child_classes) {
-				for (const auto &[reg_a, words] : word_map) {
-					auto [child_it, is_new] = nodes_.insert({words, std::make_shared<Node>(words)});
-					const std::shared_ptr<Node> &child_ptr = child_it->second;
-					node->add_child(timed_action, child_ptr);
-					if (is_new) {
-						SPDLOG_TRACE("New child: {}", words);
-						new_children.insert(child_ptr.get());
-					} else {
-						existing_children.insert(child_ptr.get());
-					}
+			for (const auto &[timed_action, words] : child_classes) {
+				auto [child_it, is_new] = nodes_.insert({words, std::make_shared<Node>(words)});
+				const std::shared_ptr<Node> &child_ptr = child_it->second;
+				node->add_child(timed_action, child_ptr);
+				SPDLOG_TRACE("Action ({}, {}): Adding child {}",
+				             timed_action.first,
+				             timed_action.second,
+				             words);
+				if (is_new) {
+					new_children.insert(child_ptr.get());
+				} else {
+					existing_children.insert(child_ptr.get());
 				}
 			}
 		}

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -245,7 +245,11 @@ get_time_successors(const CanonicalABWord<Location, ConstraintSymbolType> &canon
 	}
 	return time_successors;
 }
-
+/** Compute the direct time successors which introduce an increment in the ATA configuration for each of the passed words.
+ * @param canonical_words The set of canonical words to compute time successors of
+ * @param K The maximal constant
+ * @return All direct time successors of the passed words
+ */
 template <typename Location, typename ConstraintSymbolType>
 std::set<CanonicalABWord<Location, ConstraintSymbolType>>
 get_next_time_successors(

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -165,11 +165,11 @@ TEST_CASE("Compute clock constraints from outgoing actions", "[controller]")
 	      == std::multimap<std::string, std::multimap<std::string, automata::ClockConstraint>>{
 	        {"a",
 	         std::multimap<std::string, automata::ClockConstraint>{
-	           // TODO The first two constraints are correct actually unnecessary as they are implied
-	           // by the third constraint. We should only produce the third constraint.
 	           {"c1", automata::AtomicClockConstraintT<std::greater<Time>>{0}},
 	           {"c1", automata::AtomicClockConstraintT<std::less<Time>>{1}},
-	           {"c2", automata::AtomicClockConstraintT<std::equal_to<Time>>{1}}}}});
+	           {"c2", automata::AtomicClockConstraintT<std::greater<Time>>{0}},
+	           {"c2", automata::AtomicClockConstraintT<std::less<Time>>{1}},
+	         }}});
 	// TODO Fix this test, it tested constraint merging, which is broken
 	// CHECK(get_constraints_from_outgoing_action<std::string, std::string>(
 	//        {search::CanonicalABWord<std::string, std::string>(

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -6,7 +6,7 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_INFO
 #include "mtl/MTLFormula.h"
 #include "mtl_ata_translation/translator.h"
 #include "search/create_controller.h"
@@ -203,27 +203,42 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 			// starts with [{(l0, x, 0), ((a U b), 3)}]
 			const auto &children = root_children.at({3, "a"})->get_children();
 			CHECK(root_children.at({3, "a"})->state == NodeState::UNKNOWN);
-			// (3, a), (4, a), (5, a), (0, b), (1, b)
-			REQUIRE(children.size() == 5);
+			// 1 -> (l0, 1), (spec, 3)
+			// 2 -> (spec, 4), (l0, 1)
+			// 3 -> (spec, 5), (l0, 1)
+			// 4 -> (spec, 5), (l0, 2)
+			// 5 -> (spec, 5), (l0, 3)
+			// 6 -> (spec, 5), (l0, 4)
+			// 7 -> (spec, 5), (l0, 5)
+			REQUIRE(children.size() >= 7);
+			CHECK(children.size() == 7);
 			CHECK(get_map_keys(children)
 			      == std::set<std::pair<RegionIndex, std::string>>{
-			        {3, "a"}, {4, "a"}, {5, "a"}, {0, "b"}, {1, "b"}});
-			CHECK(children.at({3, "a"})->words
+			        {5, "a"}, {6, "a"}, {7, "a"}, {0, "b"}, {1, "b"}, {2, "b"}, {3, "b"}});
+			CHECK(children.at({5, "a"})->words
 			      == std::set{CanonicalABWord(
 			        {{TARegionState{Location{"l0"}, "x", 0}}, {ATARegionState{spec, 5}}})});
 			// Directly from the root with (5, a)
-			CHECK(children.at({3, "a"})->min_total_region_increments == 5);
+			CHECK(children.at({5, "a"})->min_total_region_increments == 5);
 			// They point to the same node.
-			CHECK(children.at({3, "a"}) == children.at({4, "a"}));
-			CHECK(children.at({3, "a"}) == children.at({5, "a"}));
+			CHECK(children.at({5, "a"}) == children.at({6, "a"}));
+			CHECK(children.at({5, "a"}) == children.at({7, "a"}));
 
 			CHECK(children.at({0, "b"})->words
 			      == std::set{CanonicalABWord({{TARegionState{Location{"l1"}, "x", 0},
 			                                    ATARegionState{logic::MTLFormula{AP{"sink"}}, 0}}})});
 			CHECK(children.at({0, "b"})->min_total_region_increments == 3);
 			CHECK(children.at({1, "b"})->words
-			      == std::set{CanonicalABWord({{TARegionState{Location{"l1"}, "x", 1}}})});
+			      == std::set{CanonicalABWord(
+			        {{ATARegionState{AP{"sink"}, 0}}, {TARegionState{Location{"l1"}, "x", 1}}})});
 			CHECK(children.at({1, "b"})->min_total_region_increments == 4);
+			CHECK(children.at({2, "b"})->words
+			      == std::set{CanonicalABWord({{TARegionState{Location{"l1"}, "x", 1}}})});
+			CHECK(children.at({2, "b"})->min_total_region_increments == 5);
+			CHECK(children.at({3, "b"})->words
+			      == std::set{CanonicalABWord({{TARegionState{Location{"l1"}, "x", 1}}})});
+			// We reach the same child with {2, "b"}.
+			CHECK(children.at({3, "b"})->min_total_region_increments == 5);
 		}
 	}
 
@@ -244,7 +259,8 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		      == std::set<std::pair<RegionIndex, std::string>>{
 		        {3, "a"}, {4, "a"}, {5, "a"}, {0, "b"}, {1, "b"}});
 		CHECK(search.get_root()->get_children().size() == 5);
-		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().size() == 5);
+		CAPTURE(search.get_root()->get_children().at({3, "a"})->get_children());
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().size() == 7);
 		// They are not equal because they have different ATA components.
 		CHECK(search.get_root()->get_children().at({3, "a"})
 		      != search.get_root()->get_children().at({4, "a"}));
@@ -282,11 +298,19 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		// The node has children, therefore its state should be UNKNOWN.
 		// Note that even though it has a self-loop, it is not monotonically dominating, as we exclude
 		// self loops in the monotonic domination check.
-		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({3, "a"})->state
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({5, "a"})->state
+		      == NodeState::UNKNOWN);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({6, "a"})->state
+		      == NodeState::UNKNOWN);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({7, "a"})->state
 		      == NodeState::UNKNOWN);
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({0, "b"})->state
 		      == NodeState::GOOD);
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({1, "b"})->state
+		      == NodeState::GOOD);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({2, "b"})->state
+		      == NodeState::BAD);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({3, "b"})->state
 		      == NodeState::BAD);
 
 		CHECK(search.get_root()->label == NodeLabel::TOP);
@@ -294,15 +318,23 @@ TEST_CASE("Search in an ABConfiguration tree", "[search]")
 		CHECK(search.get_root()->get_children().at({0, "b"})->label == NodeLabel::TOP);
 		CHECK(search.get_root()->get_children().at({1, "b"})->label == NodeLabel::TOP);
 		// The node only has bad children.
-		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({3, "a"})->label
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({5, "a"})->label
+		      == NodeLabel::BOTTOM);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({6, "a"})->label
+		      == NodeLabel::BOTTOM);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({7, "a"})->label
 		      == NodeLabel::BOTTOM);
 		// (3, a) -> (0, b) should be labeled with top, as it the constraint a U>=2 b can no longer be
 		// satisfied.
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({0, "b"})->label
 		      == NodeLabel::TOP);
-		// TODO This check is flaky for some reason.
-		// (3, a) -> (1, b) should be labeled with bottom, as it satisfied the constraint a U>=2 b
 		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({1, "b"})->label
+		      == NodeLabel::TOP);
+		// TODO This check is flaky for some reason.
+		// (3, a) -> (2, b) should be labeled with bottom, as it satisfied the constraint a U>=2 b
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({2, "b"})->label
+		      == NodeLabel::BOTTOM);
+		CHECK(search.get_root()->get_children().at({3, "a"})->get_children().at({3, "b"})->label
 		      == NodeLabel::BOTTOM);
 	}
 	SECTION("Compare to incremental labeling")

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -38,6 +38,7 @@ using CanonicalABWord = search::CanonicalABWord<automata::ta::Location<std::stri
 using search::get_canonical_word;
 using search::get_nth_time_successor;
 using search::get_time_successor;
+using search::get_time_successors;
 using search::InvalidCanonicalWordException;
 using search::is_valid_canonical_word;
 using TARegionState = search::PlantRegionState<automata::ta::Location<std::string>>;
@@ -273,6 +274,31 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                     3)
 	      == search::get_nth_time_successor(
 	        CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 8, 3));
+}
+
+TEST_CASE("Compute the time successors of a set of nodes", "[canonical_word]")
+{
+	const CanonicalABWord w1{{TARegionState{Location{"s0"}, "c0", 0}}};
+	const CanonicalABWord w2{{TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w3{{TARegionState{Location{"s0"}, "c0", 2}}};
+	const CanonicalABWord w4{{TARegionState{Location{"s0"}, "c0", 3}}};
+	const auto            words      = std::set{{w1, w2, w3, w4}};
+	const auto            successors = get_time_successors(words, 1);
+	REQUIRE(successors.at(w1).size() == 4);
+	REQUIRE(successors.at(w2).size() == 4);
+	REQUIRE(successors.at(w3).size() == 4);
+	REQUIRE(successors.at(w4).size() == 4);
+	for (auto i = 0; i < 4; ++i) {
+		CHECK(successors.at(w1)[i].first == successors.at(w2)[i].first);
+		CHECK(successors.at(w1)[i].first == successors.at(w3)[i].first);
+		CHECK(successors.at(w1)[i].first == successors.at(w4)[i].first);
+	}
+	CHECK(successors.at(w2)[2].second == successors.at(w2)[3].second);
+	CHECK(successors.at(w3)[1].second == successors.at(w3)[2].second);
+	CHECK(successors.at(w3)[2].second == successors.at(w3)[3].second);
+	CHECK(successors.at(w4)[0].second == successors.at(w4)[3].second);
+	CHECK(successors.at(w4)[1].second == successors.at(w4)[3].second);
+	CHECK(successors.at(w4)[2].second == successors.at(w4)[3].second);
 }
 
 TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -173,16 +173,16 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                          {TARegionState{Location{"s0"}, "c1", 1}}}),
 	                         3)
 	      == CanonicalABWord(
-	        {{TARegionState{Location{"s0"}, "c1", 2}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
+	        {{TARegionState{Location{"s0"}, "c0", 1}}, {TARegionState{Location{"s0"}, "c1", 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 3)
 	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
 	                                          {TARegionState{Location{"s0"}, "c1", 1}},
 	                                          {TARegionState{Location{"s0"}, "c2", 3}}}),
 	                         3)
-	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c2", 4}},
-	                          {TARegionState{Location{"s0"}, "c0", 1}},
-	                          {TARegionState{Location{"s0"}, "c1", 1}}}));
+	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
+	                          {TARegionState{Location{"s0"}, "c1", 1}},
+	                          {TARegionState{Location{"s0"}, "c2", 3}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
 	                                          {TARegionState{Location{"s0"}, "c1", 3}}}),
 	                         3)
@@ -200,7 +200,7 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                          {ATARegionState{a || b, 3}}}),
 	                         3)
 	      == CanonicalABWord(
-	        {{ATARegionState{a || b, 4}}, {ATARegionState{a, 1}}, {ATARegionState{b, 1}}}));
+	        {{ATARegionState{a, 1}}, {ATARegionState{b, 1}}, {ATARegionState{a || b, 3}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{a, 7}}}), 3)
 	      == CanonicalABWord({{ATARegionState{a, 7}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 3}}, {ATARegionState{a, 7}}}), 3)
@@ -213,8 +213,8 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                          {TARegionState{Location{"s0"}, "c0", 3}},
 	                                          {ATARegionState{a, 7}}}),
 	                         3)
-	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 4}},
-	                          {TARegionState{Location{"s1"}, "c0", 5}},
+	      == CanonicalABWord({{TARegionState{Location{"s1"}, "c0", 5}},
+	                          {TARegionState{Location{"s0"}, "c0", 3}},
 	                          {ATARegionState{a, 7}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 1}, ATARegionState{a, 3}}}), 3)
 	      == CanonicalABWord({{ATARegionState{b, 2}, ATARegionState{a, 4}}}));
@@ -226,8 +226,8 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                                         {TARegionState{Location{"l0"}, "x3", 3}}},
 	                         1)
-	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x1", 2}},
-	                         {TARegionState{Location{"l0"}, "x0", 1}},
+	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 1}},
+	                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                         {TARegionState{Location{"l0"}, "x3", 3}}});
 	// x2 is incremented and should end up in the last partition with the maxed regions.
 	CHECK(get_time_successor(CanonicalABWord{{TARegionState{Location{"l0"}, "x2", 2}},
@@ -235,15 +235,13 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                         1)
 	      == CanonicalABWord{
 	        {TARegionState{Location{"l0"}, "x2", 3}, TARegionState{Location{"l0"}, "x3", 3}}});
-	// x2 is also incremented (as it is even. It should end up in the last partition with the maxed
-	// regions.
 	CHECK(get_time_successor(CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 0},
 	                                          TARegionState{Location{"l0"}, "x2", 2}},
 	                                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                                         {TARegionState{Location{"l0"}, "x3", 3}}},
 	                         1)
-	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x1", 2}},
-	                         {TARegionState{Location{"l0"}, "x0", 1}},
+	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 1}},
+	                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                         {TARegionState{Location{"l0"}, "x2", 3},
 	                          TARegionState{Location{"l0"}, "x3", 3}}});
 
@@ -274,31 +272,175 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                     3)
 	      == search::get_nth_time_successor(
 	        CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 8, 3));
+	CHECK(get_time_successor(CanonicalABWord{{ATARegionState{a, 0}},
+	                                         {TARegionState{Location{"s0"}, "c0", 1}}},
+	                         1)
+	      == CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 1}}});
+	CHECK(get_time_successor(CanonicalABWord{{ATARegionState{a, 1}},
+	                                         {TARegionState{Location{"s0"}, "c0", 1}}},
+	                         1)
+	      == CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 1}}});
 }
 
 TEST_CASE("Compute the time successors of a set of nodes", "[canonical_word]")
 {
-	const CanonicalABWord w1{{TARegionState{Location{"s0"}, "c0", 0}}};
-	const CanonicalABWord w2{{TARegionState{Location{"s0"}, "c0", 1}}};
-	const CanonicalABWord w3{{TARegionState{Location{"s0"}, "c0", 2}}};
-	const CanonicalABWord w4{{TARegionState{Location{"s0"}, "c0", 3}}};
-	const auto            words      = std::set{{w1, w2, w3, w4}};
-	const auto            successors = get_time_successors(words, 1);
-	REQUIRE(successors.at(w1).size() == 4);
-	REQUIRE(successors.at(w2).size() == 4);
-	REQUIRE(successors.at(w3).size() == 4);
-	REQUIRE(successors.at(w4).size() == 4);
-	for (auto i = 0; i < 4; ++i) {
-		CHECK(successors.at(w1)[i].first == successors.at(w2)[i].first);
-		CHECK(successors.at(w1)[i].first == successors.at(w3)[i].first);
-		CHECK(successors.at(w1)[i].first == successors.at(w4)[i].first);
+	const logic::AtomicProposition<std::string> a{"a"};
+	const logic::AtomicProposition<std::string> b{"b"};
+	const logic::AtomicProposition<std::string> c{"c"};
+
+	const CanonicalABWord w1{{TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w2{{ATARegionState{a, 0}}, {TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w3{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w4{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{c, 1}}};
+	const CanonicalABWord w5{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{a, 1}}};
+	SECTION("first pair")
+	{
+		const auto words      = std::set{{w1, w2}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 6);
+		REQUIRE(successors.size() >= 6);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 1}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{a, 2}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[5]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{a, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
 	}
-	CHECK(successors.at(w2)[2].second == successors.at(w2)[3].second);
-	CHECK(successors.at(w3)[1].second == successors.at(w3)[2].second);
-	CHECK(successors.at(w3)[2].second == successors.at(w3)[3].second);
-	CHECK(successors.at(w4)[0].second == successors.at(w4)[3].second);
-	CHECK(successors.at(w4)[1].second == successors.at(w4)[3].second);
-	CHECK(successors.at(w4)[2].second == successors.at(w4)[3].second);
+	SECTION("second pair")
+	{
+		const auto words      = std::set{{w1, w3}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 3);
+		REQUIRE(successors.size() >= 3);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}},
+		        CanonicalABWord{{ATARegionState{b, 2}, TARegionState{Location{"s0"}, "c0", 2}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+	}
+	SECTION("third pair")
+	{
+		const auto words      = std::set{{w2, w3}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 6);
+		REQUIRE(successors.size() >= 6);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 1}}},
+		        CanonicalABWord{{ATARegionState{b, 2}, TARegionState{Location{"s0"}, "c0", 2}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 2}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[5]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+	}
+	SECTION("fourth pair")
+	{
+		const auto words      = std::set{{w3, w4}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 5);
+		REQUIRE(successors.size() >= 5);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{c, 2}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{c, 3}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 2}, TARegionState{Location{"s0"}, "c0", 2}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{c, 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}, ATARegionState{c, 3}}},
+		      });
+	}
+	SECTION("fifth pair")
+	{
+		// We assume that both clocks have the same value, because they are in the same region and both
+		// have the same position relative to the TA states. However, this assumption is not necessarily
+		// correct!
+		const auto words      = std::set{{w4, w5}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 5);
+		REQUIRE(successors.size() >= 5);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{c, 2}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{a, 2}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{c, 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{a, 3}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{c, 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}, ATARegionState{c, 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}, ATARegionState{a, 3}}},
+		      });
+	}
 }
 
 TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")


### PR DESCRIPTION
If a node contains a word that already only contains clocks in the maximal region, then it only has a single time successors, because there is no increment that changes the successor. However, the node may have another word with more time successors.  When computing the successor nodes, we also need to consider the first word, even for a higher time increment. Otherwise, the successor of the first word is missing from the successor node.

The second part fixes a related but more general problem:
When computing the time successor for a node, we need to
consider all canonical words in the node. Parts of this was fixed in the first part (28e054f8b3ff4811e53ed876fbaae64b7b6e17be), however, that fix is incomplete. As an example, consider a
node with two words:
1. `{ (l0, c, 1) }`
2. `{ (ATA, 0) }, { (l0, c, 1) }`

Then the first time successor of (2) increments the clock of the ATA but
not of the TA. However, in word (1), there is no ATA component to
increment. Therefore, the time successor with increment 1 must be the
same word. To compute these time successors correctly, we first compute
the time successors of each word. We then check if there is any word
where the reg_a does not change. If that is the case, then we need to
keep the original word for any word where the time successor has a
change reg_a.

Fixes #165.