### PR TITLE
Compute time successors for all possible increments of the node

### DIFF
--- a/src/search/include/search/search.h
+++ b/src/search/include/search/search.h
@@ -387,8 +387,8 @@ private:
 		const auto time_successors = get_time_successors(node->words, K_);
 		for (const auto &symbol : ta_->get_alphabet()) {
 			std::set<std::pair<RegionIndex, CanonicalABWord<Location, ConstraintSymbolType>>> successors;
-			for (const auto &[_, word_successors] : time_successors) {
-				for (const auto &[increment, time_successor] : word_successors) {
+			for (std::size_t increment = 0; increment < time_successors.size(); ++increment) {
+				for (const auto &time_successor : time_successors[increment]) {
 					for (const auto &successor : get_next_canonical_words<Location,
 					                                                      ActionType,
 					                                                      ConstraintSymbolType,

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #pragma once
 
 #include "automata/ata.h"
@@ -78,7 +77,7 @@ public:
 	template <typename Location, typename ConstraintSymbolType>
 	explicit InvalidCanonicalWordException(
 	  const CanonicalABWord<Location, ConstraintSymbolType> &word,
-	  const std::string &                                    error)
+	  const std::string                                     &error)
 	: std::domain_error("")
 	{
 		std::stringstream msg;
@@ -304,7 +303,7 @@ get_time_successor(const CanonicalABWord<Location, ConstraintSymbolType> &word,
  */
 template <typename Location, typename ConstraintSymbolType>
 CanonicalABWord<Location, ConstraintSymbolType>
-get_canonical_word(const automata::ta::Configuration<Location> & ta_configuration,
+get_canonical_word(const automata::ta::Configuration<Location>  &ta_configuration,
                    const ATAConfiguration<ConstraintSymbolType> &ata_configuration,
                    const unsigned int                            K)
 {
@@ -379,7 +378,7 @@ get_candidate(const CanonicalABWord<Location, ConstraintSymbolType> &word)
 		for (const ABRegionSymbol<Location, ConstraintSymbolType> &symbol : abs_i) {
 			// TODO Refactor, fractional/integral outside of if
 			if (std::holds_alternative<TARegionState<Location>>(symbol)) {
-				const auto &      ta_region_state = std::get<TARegionState<Location>>(symbol);
+				const auto       &ta_region_state = std::get<TARegionState<Location>>(symbol);
 				const RegionIndex region_index    = ta_region_state.region_index;
 				const Time        fractional_part =
           region_index % 2 == 0 ? 0 : time_delta * static_cast<Time>((i + 1));
@@ -389,7 +388,7 @@ get_candidate(const CanonicalABWord<Location, ConstraintSymbolType> &word)
 				ta_configuration.location                     = ta_region_state.location;
 				ta_configuration.clock_valuations[clock_name] = integral_part + fractional_part;
 			} else { // ATARegionState<ConstraintSymbolType>
-				const auto &      ata_region_state = std::get<ATARegionState<ConstraintSymbolType>>(symbol);
+				const auto       &ata_region_state = std::get<ATARegionState<ConstraintSymbolType>>(symbol);
 				const RegionIndex region_index     = ata_region_state.region_index;
 				const Time        fractional_part =
           region_index % 2 == 0 ? 0 : time_delta * static_cast<Time>((i + 1));
@@ -421,7 +420,7 @@ get_nth_time_successor(const CanonicalABWord<Location, ConstraintSymbolType> &wo
 }
 
 /** Compute all time successors of a canonical word.
- * @param canonical_word The canonical to compute the time successors of
+ * @param canonical_word The canonical word to compute the time successors of
  * @param K The maximal constant
  * @return All time successors of the word along with the region increment to reach the successor
  */
@@ -458,7 +457,7 @@ get_next_canonical_words(
                                                  logic::AtomicProposition<ConstraintSymbolType>>
     &ata,
   const std::pair<TAConfiguration<Location>, ATAConfiguration<ConstraintSymbolType>>
-    &               ab_configuration,
+                   &ab_configuration,
   const ActionType &symbol,
   RegionIndex       K)
 {
@@ -502,4 +501,33 @@ get_next_canonical_words(
 	return res;
 }
 
+/** Compute all time successors of a set of canonical words (i.e., of a node in the search tree).
+ * @param canonical_words A set of canonical words to compute the time successors of
+ * @param K The maximal constant
+ * @return A map of time successors of each word along with the region increment to reach the
+ * successor
+ */
+template <typename Location, typename ConstraintSymbolType>
+std::map<CanonicalABWord<Location, ConstraintSymbolType>,
+         std::vector<std::pair<RegionIndex, CanonicalABWord<Location, ConstraintSymbolType>>>>
+get_time_successors(
+  const std::set<CanonicalABWord<Location, ConstraintSymbolType>> &canonical_words,
+  RegionIndex                                                      K)
+{
+	std::map<CanonicalABWord<Location, ConstraintSymbolType>,
+	         std::vector<std::pair<RegionIndex, CanonicalABWord<Location, ConstraintSymbolType>>>>
+	            res;
+	std::size_t num_successors = 0;
+	for (const auto &word : canonical_words) {
+		const auto successors = get_time_successors(word, K);
+		num_successors        = std::max(num_successors, successors.size());
+		res[word]             = successors;
+	}
+	for (auto &&[_, successors] : res) {
+		for (std::size_t i = successors.size(); i < num_successors; ++i) {
+			successors.push_back(std::make_pair(i, successors.back().second));
+		}
+	}
+	return res;
+}
 } // namespace tacos::search

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -494,6 +494,12 @@ get_next_canonical_words(
 	return res;
 }
 
+/** Compute the direct time successors which introduce an increment in the ATA configuration for
+ * each of the passed words.
+ * @param canonical_words The set of canonical words to compute time successors of
+ * @param K The maximal constant
+ * @return All direct time successors of the passed words
+ */
 template <typename Location, typename ConstraintSymbolType>
 std::set<CanonicalABWord<Location, ConstraintSymbolType>>
 get_next_time_successors(

--- a/src/search/include/search/synchronous_product.h
+++ b/src/search/include/search/synchronous_product.h
@@ -237,7 +237,23 @@ get_time_successor(const CanonicalABWord<Location, ConstraintSymbolType> &word,
 		// All partitions are maxed, nothing to increment.
 		return word;
 	}
-	{
+	const bool has_even_region_index = get_region_index(*word.begin()->begin()) % 2 == 0;
+	// The first set needs to be incremented if its region indexes are even.
+	if (has_even_region_index) {
+		auto incremented = increment_region_indexes(*word.begin(), max_region_index);
+		std::set<ABRegionSymbol<Location, ConstraintSymbolType>> incremented_nonmaxed;
+		for (auto &configuration : incremented) {
+			if (get_region_index(configuration) == max_region_index) {
+				new_maxed_partition.insert(configuration);
+			} else {
+				incremented_nonmaxed.insert(configuration);
+			}
+		}
+		if (!incremented_nonmaxed.empty()) {
+			res.push_back(std::move(incremented_nonmaxed));
+		}
+		std::reverse_copy(last_nonmaxed_partition, std::prev(word.rend()), std::back_inserter(res));
+	} else {
 		// Increment the last nonmaxed partition. If we have a new maxed configuration, put it into the
 		// maxed partition. Otherwise, keep it in place.
 		auto incremented = increment_region_indexes(*last_nonmaxed_partition, max_region_index);
@@ -252,32 +268,9 @@ get_time_successor(const CanonicalABWord<Location, ConstraintSymbolType> &word,
 		if (!incremented_nonmaxed.empty()) {
 			res.push_back(std::move(incremented_nonmaxed));
 		}
+		std::reverse_copy(std::next(last_nonmaxed_partition), word.rend(), std::back_inserter(res));
 	}
 
-	// Process all partitions before the last nonmaxed partition.
-	if (std::prev(std::rend(word)) != last_nonmaxed_partition) {
-		// The first set needs to be incremented if its region indexes are even.
-		if (get_region_index(*word.begin()->begin()) % 2 == 0) {
-			auto incremented = increment_region_indexes(*word.begin(), max_region_index);
-			std::set<ABRegionSymbol<Location, ConstraintSymbolType>> incremented_nonmaxed;
-			for (auto &configuration : incremented) {
-				if (get_region_index(configuration) == max_region_index) {
-					new_maxed_partition.insert(configuration);
-				} else {
-					incremented_nonmaxed.insert(configuration);
-				}
-			}
-			if (!incremented_nonmaxed.empty()) {
-				res.push_back(std::move(incremented_nonmaxed));
-			}
-		} else {
-			res.push_back(*word.begin());
-		}
-		// Copy all other abs_i which are not the first nor the last. Those never change.
-		std::reverse_copy(std::next(last_nonmaxed_partition),
-		                  std::prev(word.rend()),
-		                  std::back_inserter(res));
-	}
 	// If the maxed partition is non-empty, add it to the resulting word.
 	if (!new_maxed_partition.empty()) {
 		res.push_back(std::move(new_maxed_partition));
@@ -501,6 +494,44 @@ get_next_canonical_words(
 	return res;
 }
 
+template <typename Location, typename ConstraintSymbolType>
+std::set<CanonicalABWord<Location, ConstraintSymbolType>>
+get_next_time_successors(
+  const std::set<CanonicalABWord<Location, ConstraintSymbolType>> &canonical_words,
+  RegionIndex                                                      K)
+{
+	assert(!canonical_words.empty());
+	assert(std::all_of(std::begin(canonical_words), std::end(canonical_words), [&](const auto &word) {
+		return reg_a(word) == reg_a(*std::begin(canonical_words));
+	}));
+	std::set<CanonicalABWord<Location, ConstraintSymbolType>> successors;
+	std::map<CanonicalABWord<Location, ConstraintSymbolType>,
+	         CanonicalABWord<Location, ConstraintSymbolType>>
+	  successors_map;
+	for (const auto &word : canonical_words) {
+		successors_map[word] = get_time_successor(word, K);
+	}
+	if (std::any_of(std::begin(successors_map), std::end(successors_map), [](const auto &map_entry) {
+		    return reg_a(map_entry.first) == reg_a(map_entry.second);
+	    })) {
+		// There is at least one where the successor has the same reg_a and thus there is an ATA
+		// configuration that is incremented. We must only increments those where there is also an ATA
+		// configuration to increment.
+		for (const auto &[word, successor] : successors_map) {
+			if (reg_a(word) == reg_a(successor)) {
+				successors.insert(successor);
+			} else {
+				successors.insert(word);
+			}
+		}
+	} else {
+		for (const auto &[_, successor] : successors_map) {
+			successors.insert(successor);
+		}
+	}
+	return successors;
+}
+
 /** Compute all time successors of a set of canonical words (i.e., of a node in the search tree).
  * @param canonical_words A set of canonical words to compute the time successors of
  * @param K The maximal constant
@@ -508,26 +539,22 @@ get_next_canonical_words(
  * successor
  */
 template <typename Location, typename ConstraintSymbolType>
-std::map<CanonicalABWord<Location, ConstraintSymbolType>,
-         std::vector<std::pair<RegionIndex, CanonicalABWord<Location, ConstraintSymbolType>>>>
+std::vector<std::set<CanonicalABWord<Location, ConstraintSymbolType>>>
 get_time_successors(
   const std::set<CanonicalABWord<Location, ConstraintSymbolType>> &canonical_words,
   RegionIndex                                                      K)
 {
-	std::map<CanonicalABWord<Location, ConstraintSymbolType>,
-	         std::vector<std::pair<RegionIndex, CanonicalABWord<Location, ConstraintSymbolType>>>>
-	            res;
-	std::size_t num_successors = 0;
-	for (const auto &word : canonical_words) {
-		const auto successors = get_time_successors(word, K);
-		num_successors        = std::max(num_successors, successors.size());
-		res[word]             = successors;
-	}
-	for (auto &&[_, successors] : res) {
-		for (std::size_t i = successors.size(); i < num_successors; ++i) {
-			successors.push_back(std::make_pair(i, successors.back().second));
+	std::vector<std::set<CanonicalABWord<Location, ConstraintSymbolType>>> successors;
+	successors.push_back(canonical_words);
+	while (true) {
+		const auto next = get_next_time_successors(successors.back(), K);
+		if (next != successors.back()) {
+			successors.push_back(next);
+		} else {
+			break;
 		}
 	}
-	return res;
+	return successors;
 }
+
 } // namespace tacos::search

--- a/test/test_create_controller.cpp
+++ b/test/test_create_controller.cpp
@@ -6,7 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_TRACE
 
 #include "automata/automata.h"
@@ -91,18 +90,18 @@ TEST_CASE("Controller time bounds", "[.railroad][controller]")
         {Location{"CLOSED"}},
         {"c"},
         {Transition{Location{"OPEN"}, "start_close", Location{"CLOSING"}, {}, {"c"}},
-         Transition{Location{"CLOSING"},
+	               Transition{Location{"CLOSING"},
                     "finish_close",
                     Location{"CLOSED"},
                     {{"c", automata::AtomicClockConstraintT<std::equal_to<automata::Time>>{4}}},
                     {"c"}},
-         Transition{Location{"CLOSED"},
+	               Transition{Location{"CLOSED"},
                     "start_open",
                     Location{"OPENING"},
                     {{"c",
-                      automata::AtomicClockConstraintT<std::greater_equal<automata::Time>>{1}}},
+	                            automata::AtomicClockConstraintT<std::greater_equal<automata::Time>>{1}}},
                     {"c"}},
-         Transition{Location{"OPENING"},
+	               Transition{Location{"OPENING"},
                     "finish_open",
                     Location{"OPEN"},
                     {{"c", automata::AtomicClockConstraintT<std::equal_to<automata::Time>>{4}}},
@@ -170,11 +169,11 @@ TEST_CASE("Compute clock constraints from outgoing actions", "[controller]")
 	      == std::multimap<std::string, std::multimap<std::string, automata::ClockConstraint>>{
 	        {"a",
 	         std::multimap<std::string, automata::ClockConstraint>{
-	           // TODO The first two constraints are correct actually unnecessary as they are implied
-	           // by the third constraint. We should only produce the third constraint.
 	           {"c1", automata::AtomicClockConstraintT<std::greater<automata::Time>>{0}},
 	           {"c1", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}},
-	           {"c2", automata::AtomicClockConstraintT<std::equal_to<automata::Time>>{1}}}}});
+	           {"c2", automata::AtomicClockConstraintT<std::greater<automata::Time>>{0}},
+	           {"c2", automata::AtomicClockConstraintT<std::less<automata::Time>>{1}},
+	         }}});
 	// TODO Fix this test, it tested constraint merging, which is broken
 	// CHECK(get_constraints_from_outgoing_action<std::string, std::string>(
 	//        {search::CanonicalABWord<std::string, std::string>(

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -41,6 +41,7 @@ using CanonicalABWord = search::CanonicalABWord<std::string, std::string>;
 using search::get_canonical_word;
 using search::get_nth_time_successor;
 using search::get_time_successor;
+using search::get_time_successors;
 using search::InvalidCanonicalWordException;
 using search::is_valid_canonical_word;
 using TARegionState = search::TARegionState<std::string>;
@@ -280,6 +281,31 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                     3)
 	      == search::get_nth_time_successor(
 	        CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 8, 3));
+}
+
+TEST_CASE("Compute the time successors of a set of nodes", "[canonical_word]")
+{
+	const CanonicalABWord w1{{TARegionState{Location{"s0"}, "c0", 0}}};
+	const CanonicalABWord w2{{TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w3{{TARegionState{Location{"s0"}, "c0", 2}}};
+	const CanonicalABWord w4{{TARegionState{Location{"s0"}, "c0", 3}}};
+	const auto            words      = std::set{{w1, w2, w3, w4}};
+	const auto            successors = get_time_successors(words, 1);
+	REQUIRE(successors.at(w1).size() == 4);
+	REQUIRE(successors.at(w2).size() == 4);
+	REQUIRE(successors.at(w3).size() == 4);
+	REQUIRE(successors.at(w4).size() == 4);
+	for (auto i = 0; i < 4; ++i) {
+		CHECK(successors.at(w1)[i].first == successors.at(w2)[i].first);
+		CHECK(successors.at(w1)[i].first == successors.at(w3)[i].first);
+		CHECK(successors.at(w1)[i].first == successors.at(w4)[i].first);
+	}
+	CHECK(successors.at(w2)[2].second == successors.at(w2)[3].second);
+	CHECK(successors.at(w3)[1].second == successors.at(w3)[2].second);
+	CHECK(successors.at(w3)[2].second == successors.at(w3)[3].second);
+	CHECK(successors.at(w4)[0].second == successors.at(w4)[3].second);
+	CHECK(successors.at(w4)[1].second == successors.at(w4)[3].second);
+	CHECK(successors.at(w4)[2].second == successors.at(w4)[3].second);
 }
 
 TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")

--- a/test/test_synchronous_product.cpp
+++ b/test/test_synchronous_product.cpp
@@ -180,16 +180,16 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                          {TARegionState{Location{"s0"}, "c1", 1}}}),
 	                         3)
 	      == CanonicalABWord(
-	        {{TARegionState{Location{"s0"}, "c1", 2}}, {TARegionState{Location{"s0"}, "c0", 1}}}));
+	        {{TARegionState{Location{"s0"}, "c0", 1}}, {TARegionState{Location{"s0"}, "c1", 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 3)
 	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}},
 	                                          {TARegionState{Location{"s0"}, "c1", 1}},
 	                                          {TARegionState{Location{"s0"}, "c2", 3}}}),
 	                         3)
-	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c2", 4}},
-	                          {TARegionState{Location{"s0"}, "c0", 1}},
-	                          {TARegionState{Location{"s0"}, "c1", 1}}}));
+	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
+	                          {TARegionState{Location{"s0"}, "c1", 1}},
+	                          {TARegionState{Location{"s0"}, "c2", 3}}}));
 	CHECK(get_time_successor(CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 1}},
 	                                          {TARegionState{Location{"s0"}, "c1", 3}}}),
 	                         3)
@@ -207,7 +207,7 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                          {ATARegionState{a || b, 3}}}),
 	                         3)
 	      == CanonicalABWord(
-	        {{ATARegionState{a || b, 4}}, {ATARegionState{a, 1}}, {ATARegionState{b, 1}}}));
+	        {{ATARegionState{a, 1}}, {ATARegionState{b, 1}}, {ATARegionState{a || b, 3}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{a, 7}}}), 3)
 	      == CanonicalABWord({{ATARegionState{a, 7}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 3}}, {ATARegionState{a, 7}}}), 3)
@@ -220,8 +220,8 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                          {TARegionState{Location{"s0"}, "c0", 3}},
 	                                          {ATARegionState{a, 7}}}),
 	                         3)
-	      == CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 4}},
-	                          {TARegionState{Location{"s1"}, "c0", 5}},
+	      == CanonicalABWord({{TARegionState{Location{"s1"}, "c0", 5}},
+	                          {TARegionState{Location{"s0"}, "c0", 3}},
 	                          {ATARegionState{a, 7}}}));
 	CHECK(get_time_successor(CanonicalABWord({{ATARegionState{b, 1}, ATARegionState{a, 3}}}), 3)
 	      == CanonicalABWord({{ATARegionState{b, 2}, ATARegionState{a, 4}}}));
@@ -233,8 +233,8 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                                         {TARegionState{Location{"l0"}, "x3", 3}}},
 	                         1)
-	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x1", 2}},
-	                         {TARegionState{Location{"l0"}, "x0", 1}},
+	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 1}},
+	                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                         {TARegionState{Location{"l0"}, "x3", 3}}});
 	// x2 is incremented and should end up in the last partition with the maxed regions.
 	CHECK(get_time_successor(CanonicalABWord{{TARegionState{Location{"l0"}, "x2", 2}},
@@ -242,15 +242,13 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                         1)
 	      == CanonicalABWord{
 	        {TARegionState{Location{"l0"}, "x2", 3}, TARegionState{Location{"l0"}, "x3", 3}}});
-	// x2 is also incremented (as it is even. It should end up in the last partition with the maxed
-	// regions.
 	CHECK(get_time_successor(CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 0},
 	                                          TARegionState{Location{"l0"}, "x2", 2}},
 	                                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                                         {TARegionState{Location{"l0"}, "x3", 3}}},
 	                         1)
-	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x1", 2}},
-	                         {TARegionState{Location{"l0"}, "x0", 1}},
+	      == CanonicalABWord{{TARegionState{Location{"l0"}, "x0", 1}},
+	                         {TARegionState{Location{"l0"}, "x1", 1}},
 	                         {TARegionState{Location{"l0"}, "x2", 3},
 	                          TARegionState{Location{"l0"}, "x3", 3}}});
 
@@ -281,31 +279,175 @@ TEST_CASE("Get the time successor for a canonical AB word", "[canonical_word]")
 	                                     3)
 	      == search::get_nth_time_successor(
 	        CanonicalABWord({{TARegionState{Location{"s0"}, "c0", 0}}}), 8, 3));
+	CHECK(get_time_successor(CanonicalABWord{{ATARegionState{a, 0}},
+	                                         {TARegionState{Location{"s0"}, "c0", 1}}},
+	                         1)
+	      == CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 1}}});
+	CHECK(get_time_successor(CanonicalABWord{{ATARegionState{a, 1}},
+	                                         {TARegionState{Location{"s0"}, "c0", 1}}},
+	                         1)
+	      == CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 1}}});
 }
 
 TEST_CASE("Compute the time successors of a set of nodes", "[canonical_word]")
 {
-	const CanonicalABWord w1{{TARegionState{Location{"s0"}, "c0", 0}}};
-	const CanonicalABWord w2{{TARegionState{Location{"s0"}, "c0", 1}}};
-	const CanonicalABWord w3{{TARegionState{Location{"s0"}, "c0", 2}}};
-	const CanonicalABWord w4{{TARegionState{Location{"s0"}, "c0", 3}}};
-	const auto            words      = std::set{{w1, w2, w3, w4}};
-	const auto            successors = get_time_successors(words, 1);
-	REQUIRE(successors.at(w1).size() == 4);
-	REQUIRE(successors.at(w2).size() == 4);
-	REQUIRE(successors.at(w3).size() == 4);
-	REQUIRE(successors.at(w4).size() == 4);
-	for (auto i = 0; i < 4; ++i) {
-		CHECK(successors.at(w1)[i].first == successors.at(w2)[i].first);
-		CHECK(successors.at(w1)[i].first == successors.at(w3)[i].first);
-		CHECK(successors.at(w1)[i].first == successors.at(w4)[i].first);
+	const logic::AtomicProposition<std::string> a{"a"};
+	const logic::AtomicProposition<std::string> b{"b"};
+	const logic::AtomicProposition<std::string> c{"c"};
+
+	const CanonicalABWord w1{{TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w2{{ATARegionState{a, 0}}, {TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w3{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}};
+	const CanonicalABWord w4{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{c, 1}}};
+	const CanonicalABWord w5{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{a, 1}}};
+	SECTION("first pair")
+	{
+		const auto words      = std::set{{w1, w2}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 6);
+		REQUIRE(successors.size() >= 6);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 1}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{a, 2}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[5]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{a, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
 	}
-	CHECK(successors.at(w2)[2].second == successors.at(w2)[3].second);
-	CHECK(successors.at(w3)[1].second == successors.at(w3)[2].second);
-	CHECK(successors.at(w3)[2].second == successors.at(w3)[3].second);
-	CHECK(successors.at(w4)[0].second == successors.at(w4)[3].second);
-	CHECK(successors.at(w4)[1].second == successors.at(w4)[3].second);
-	CHECK(successors.at(w4)[2].second == successors.at(w4)[3].second);
+	SECTION("second pair")
+	{
+		const auto words      = std::set{{w1, w3}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 3);
+		REQUIRE(successors.size() >= 3);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}},
+		        CanonicalABWord{{ATARegionState{b, 2}, TARegionState{Location{"s0"}, "c0", 2}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+	}
+	SECTION("third pair")
+	{
+		const auto words      = std::set{{w2, w3}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 6);
+		REQUIRE(successors.size() >= 6);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 1}}},
+		        CanonicalABWord{{ATARegionState{b, 2}, TARegionState{Location{"s0"}, "c0", 2}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 1}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 2}}, {TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+		CHECK(successors[5]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{a, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		      });
+	}
+	SECTION("fourth pair")
+	{
+		const auto words      = std::set{{w3, w4}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 5);
+		REQUIRE(successors.size() >= 5);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{c, 2}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 1}, TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{c, 3}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 2}, TARegionState{Location{"s0"}, "c0", 2}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{c, 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{b, 3}, TARegionState{Location{"s0"}, "c0", 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}, ATARegionState{c, 3}}},
+		      });
+	}
+	SECTION("fifth pair")
+	{
+		// We assume that both clocks have the same value, because they are in the same region and both
+		// have the same position relative to the TA states. However, this assumption is not necessarily
+		// correct!
+		const auto words      = std::set{{w4, w5}};
+		const auto successors = get_time_successors(words, 1);
+		CAPTURE(successors);
+		CHECK(successors.size() == 5);
+		REQUIRE(successors.size() >= 5);
+		CHECK(successors[0] == words);
+		CHECK(successors[1]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{ATARegionState{c, 2}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		        CanonicalABWord{{ATARegionState{a, 2}}, {TARegionState{Location{"s0"}, "c0", 1}}},
+		      });
+		CHECK(successors[2]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{c, 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 1}}, {ATARegionState{a, 3}}},
+		      });
+		CHECK(successors[3]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{c, 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 2}}, {ATARegionState{a, 3}}},
+		      });
+		CHECK(successors[4]
+		      == std::set<CanonicalABWord>{
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}, ATARegionState{c, 3}}},
+		        CanonicalABWord{{TARegionState{Location{"s0"}, "c0", 3}, ATARegionState{a, 3}}},
+		      });
+	}
 }
 
 TEST_CASE("Get a concrete candidate for a canonical word", "[canonical_word]")


### PR DESCRIPTION
If a node contains a word that already only contains clocks in the maximal region, then it only has a single time successors, because there is no increment that changes the successor. However, the node may have another word with more time successors.  When computing the successor nodes, we also need to consider the first word, even for a higher time increment. Otherwise, the successor of the first word is missing from the successor node.

Therefore, compute all time successors together, by first computing the time successors for each word and then adjusting all other time successors, such that each word has a time successor for all increments.

This is a backport of #166.