### PR TITLE
circleci: build both Debug and Release build types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
     steps:
       - run:
           name: Build the project
-          command: cmake -B build -DTACOS_GOCOS=ON -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON -DTACOS_CLANG_TIDY=ON && cmake --build build -j 4
+          command: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DTACOS_GOCOS=ON -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON -DTACOS_CLANG_TIDY=ON && cmake --build build -j 4
   build_release:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ commands:
       - run:
           name: Build the project
           command: cmake -B build -DTACOS_GOCOS=ON -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON -DTACOS_CLANG_TIDY=ON && cmake --build build -j 4
+  build_release:
+    steps:
+      - run:
+          name: Build with build type 'Release'
+          command: cmake -B build -DCMAKE_BUILD_TYPE=Release -DTACOS_GOCOS=ON -DTACOS_BUILD_BENCHMARKS=ON -DTACOS_BUILD_LARGE_BENCHMARKS=ON && cmake --build build -j 4
   test:
     steps:
       - run:
@@ -66,6 +71,15 @@ jobs:
       - build
       - test
       - build_doc
+  build_release:
+    docker:
+      - image: fedora:36
+    resource_class: large
+    steps:
+      - install_build_env
+      - checkout
+      - build_release
+      - test
   build_clang:
     docker:
       - image: fedora:36
@@ -115,6 +129,7 @@ workflows:
     jobs:
       - build_gcc
       - build_clang
+      - build_release
       - generate_coverage
       - deploy_docs:
           filters:


### PR DESCRIPTION
Explicitly build with build type 'Debug' in the default step. This is necessary because some libraries default to 'Release', which may cause problems. In particular, golog++ causes segfaults if build with clang and no specified build type.

In addition to the Debug build type, also build with type 'Release' to make sure that we can also build that configuration without errors.