### PR TITLE
railroad example: add timing constraint on enter/finish_close

### DIFF
--- a/examples/railroad/spec.pbtxt
+++ b/examples/railroad/spec.pbtxt
@@ -2,31 +2,31 @@ disjunction {
   disjuncts {
     dual_until {
       front {
-        atomic { symbol: "enter" }
+        disjunction {
+          disjuncts {
+            atomic { symbol: "enter" }
+          }
+          disjuncts {
+            finally {
+              formula { atomic { symbol: "enter" } }
+              interval {
+                lower {
+                  value: 0
+                  bound_type: WEAK
+                }
+                upper {
+                  value: 1
+                  bound_type: WEAK
+                }
+              }
+            }
+          }
+        }
       }
       back {
         negation {
           formula {
-            disjunction {
-              disjuncts {
-                atomic { symbol: "finish_close" }
-              }
-              disjuncts {
-                finally {
-                  formula { atomic { symbol: "finish_close" } }
-                  interval {
-                    lower {
-                      value: 0
-                      bound_type: WEAK
-                    }
-                    upper {
-                      value: 1
-                      bound_type: WEAK
-                    }
-                  }
-                }
-              }
-            }
+            atomic { symbol: "finish_close" }
           }
         }
       }

--- a/examples/railroad/spec.pbtxt
+++ b/examples/railroad/spec.pbtxt
@@ -6,7 +6,28 @@ disjunction {
       }
       back {
         negation {
-         formula { atomic { symbol: "finish_close" } }
+          formula {
+            disjunction {
+              disjuncts {
+                atomic { symbol: "finish_close" }
+              }
+              disjuncts {
+                finally {
+                  formula { atomic { symbol: "finish_close" } }
+                  interval {
+                    lower {
+                      value: 0
+                      bound_type: WEAK
+                    }
+                    upper {
+                      value: 1
+                      bound_type: WEAK
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This requires that the gate is closed for at least 1s before the train may enter.