### PR TITLE
circleci: update ssh deploy key for GitHub Pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             npm install -g --silent gh-pages
       - add_ssh_keys:
           fingerprints:
-            - "08:ba:0d:5b:be:ab:d8:7b:46:1e:36:34:81:e4:d9:75"
+            - "78:02:22:47:89:7d:e3:76:6d:f3:89:4c:19:59:a0:b6"
       - run:
           name: Deploy docs to gh-pages branch
           command:


### PR DESCRIPTION
The circleci keys may have been compromised, therefore rotate them: https://circleci.com/blog/january-4-2023-security-alert/