### PR TITLE
Adapt to libfmt 9 by providing ostream formatter specializations

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -124,7 +124,7 @@ Launcher::parse_command_line(int argc, const char *const argv[])
 	boost::program_options::store(boost::program_options::parse_command_line(argc, argv, options),
 	                              variables);
 	if (variables.count("help")) {
-		SPDLOG_INFO(options);
+		SPDLOG_INFO(fmt::streamed(options));
 		show_help = true;
 		return;
 	}

--- a/src/automata/automata.cpp
+++ b/src/automata/automata.cpp
@@ -6,8 +6,6 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
-
 #include "automata/automata.h"
 
 namespace tacos::automata {
@@ -26,7 +24,7 @@ operator<<(std::ostream &os, const automata::ClockConstraint &constraint)
 }
 
 std::ostream &
-operator<<(std::ostream &                                               os,
+operator<<(std::ostream                                                &os,
            const std::multimap<std::string, automata::ClockConstraint> &constraints)
 {
 	if (constraints.empty()) {

--- a/src/automata/include/automata/ata.h
+++ b/src/automata/include/automata/ata.h
@@ -12,6 +12,8 @@
 #include "ata_formula.h"
 #include "automata.h"
 
+#include <fmt/ostream.h>
+
 #include <experimental/iterator>
 #include <stdexcept>
 #include <string>
@@ -252,6 +254,26 @@ private:
 };
 
 } // namespace tacos::automata::ata
+
+namespace fmt {
+
+template <typename LocationT, typename SymbolT>
+struct formatter<tacos::automata::ata::Transition<LocationT, SymbolT>> : ostream_formatter
+{
+};
+
+template <typename LocationT, typename SymbolT>
+struct formatter<tacos::automata::ata::AlternatingTimedAutomaton<LocationT, SymbolT>>
+: ostream_formatter
+{
+};
+
+template <typename LocationT, typename SymbolT>
+struct formatter<tacos::automata::ata::Run<LocationT, SymbolT>> : ostream_formatter
+{
+};
+
+} // namespace fmt
 
 #include "ata.hpp"
 

--- a/src/automata/include/automata/ata.hpp
+++ b/src/automata/include/automata/ata.hpp
@@ -7,7 +7,6 @@
  ****************************************************************************/
 
 #pragma once
-
 #include "ata.h"
 
 namespace tacos::automata::ata {

--- a/src/automata/include/automata/ata_formula.h
+++ b/src/automata/include/automata/ata_formula.h
@@ -11,6 +11,8 @@
 
 #include "automata.h"
 
+#include <fmt/ostream.h>
+
 #include <algorithm>
 #include <memory>
 #include <range/v3/algorithm.hpp>
@@ -98,8 +100,8 @@ class Formula
 public:
 	/// Constructor
 	explicit Formula(){};
-	Formula(const Formula &) = delete;
-	virtual ~Formula()       = default;
+	Formula(const Formula &)            = delete;
+	virtual ~Formula()                  = default;
 	Formula &operator=(const Formula &) = delete;
 	/** Check if the formula is satisfied by a configuration and a clock valuation.
 	 * @param states The configuration to check
@@ -107,7 +109,7 @@ public:
 	 * @return true if the formula is satisfied
 	 */
 	[[nodiscard]] virtual bool is_satisfied(const std::set<State<LocationT>> &states,
-	                                        const ClockValuation &            v) const = 0;
+	                                        const ClockValuation             &v) const = 0;
 	/** Compute the minimal model of the formula.
 	 * @param v The clock valuation to evaluate teh formula against
 	 * @return a set of minimal models, where each minimal model consists of a set of states
@@ -173,7 +175,7 @@ public:
 	 */
 	explicit LocationFormula(const LocationT &location) : location_(location){};
 	bool                                 is_satisfied(const std::set<State<LocationT>> &states,
-	                                                  const ClockValuation &            v) const override;
+	                                                  const ClockValuation             &v) const override;
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &v) const override;
 
 protected:
@@ -234,7 +236,7 @@ public:
 	}
 
 	bool is_satisfied(const std::set<State<LocationT>> &states,
-	                  const ClockValuation &            v) const override;
+	                  const ClockValuation             &v) const override;
 
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &v) const override;
 
@@ -269,7 +271,7 @@ public:
 	}
 
 	bool                                 is_satisfied(const std::set<State<LocationT>> &states,
-	                                                  const ClockValuation &            v) const override;
+	                                                  const ClockValuation             &v) const override;
 	std::set<std::set<State<LocationT>>> get_minimal_models(const ClockValuation &v) const override;
 
 protected:
@@ -346,6 +348,20 @@ std::unique_ptr<Formula<LocationT>>
 create_conjunction(std::vector<std::unique_ptr<Formula<LocationT>>> conjuncts);
 
 } // namespace tacos::automata::ata
+
+namespace fmt {
+
+template <typename LocationT>
+struct formatter<tacos::automata::ata::Formula<LocationT>> : ostream_formatter
+{
+};
+
+template <typename LocationT>
+struct formatter<tacos::automata::ata::State<LocationT>> : ostream_formatter
+{
+};
+
+} // namespace fmt
 
 #include "ata_formula.hpp"
 

--- a/src/automata/include/automata/ata_formula.hpp
+++ b/src/automata/include/automata/ata_formula.hpp
@@ -81,7 +81,7 @@ FalseFormula<LocationT>::print_to_ostream(std::ostream &os) const
 template <typename LocationT>
 bool
 LocationFormula<LocationT>::is_satisfied(const std::set<State<LocationT>> &states,
-                                         const ClockValuation &            v) const
+                                         const ClockValuation             &v) const
 {
 	return states.count(State<LocationT>{location_, v});
 }
@@ -129,7 +129,7 @@ ClockConstraintFormula<LocationT>::print_to_ostream(std::ostream &os) const
 template <typename LocationT>
 bool
 ConjunctionFormula<LocationT>::is_satisfied(const std::set<State<LocationT>> &states,
-                                            const ClockValuation &            v) const
+                                            const ClockValuation             &v) const
 {
 	return conjunct1_->is_satisfied(states, v) && conjunct2_->is_satisfied(states, v);
 }
@@ -160,7 +160,7 @@ ConjunctionFormula<LocationT>::print_to_ostream(std::ostream &os) const
 template <typename LocationT>
 bool
 DisjunctionFormula<LocationT>::is_satisfied(const std::set<State<LocationT>> &states,
-                                            const ClockValuation &            v) const
+                                            const ClockValuation             &v) const
 {
 	return disjunct1_->is_satisfied(states, v) || disjunct2_->is_satisfied(states, v);
 }

--- a/src/automata/include/automata/automata.h
+++ b/src/automata/include/automata/automata.h
@@ -11,6 +11,8 @@
 
 #include "utilities/types.h"
 
+#include <fmt/ostream.h>
+
 #include <boost/format.hpp>
 #include <functional>
 #include <iostream>
@@ -233,6 +235,32 @@ operator<(const ClockConstraint &lhs, const ClockConstraint &rhs)
 }
 
 } // namespace tacos::automata
+
+namespace fmt {
+
+template <>
+struct formatter<tacos::automata::ClockConstraint> : ostream_formatter
+{
+};
+
+template <>
+struct formatter<std::multimap<std::string, tacos::automata::ClockConstraint>> : ostream_formatter
+{
+};
+
+template <class Comp>
+struct formatter<tacos::automata::AtomicClockConstraintT<Comp>> : ostream_formatter
+{
+};
+
+template <typename ActionT>
+struct formatter<
+  std::multimap<ActionT, std::multimap<std::string, tacos::automata::ClockConstraint>>>
+: ostream_formatter
+{
+};
+
+} // namespace fmt
 
 #include "automata.hpp"
 

--- a/src/automata/include/automata/ta.h
+++ b/src/automata/include/automata/ta.h
@@ -12,6 +12,8 @@
 #include "automata.h"
 #include "utilities/types.h"
 
+#include <fmt/ostream.h>
+
 #include <NamedType/named_type.hpp>
 #include <algorithm>
 #include <functional>
@@ -482,6 +484,31 @@ template <typename T>
 std::ostream &operator<<(std::ostream &os, const std::set<T> &strings);
 
 } // namespace tacos::automata::ta
+
+namespace fmt {
+
+template <typename LocationT>
+struct formatter<tacos::automata::ta::Location<LocationT>> : ostream_formatter
+{
+};
+
+template <typename LocationT, typename AP>
+struct formatter<std::multimap<tacos::automata::ta::Location<LocationT>,
+                               tacos::automata::ta::Transition<LocationT, AP>>> : ostream_formatter
+{
+};
+
+template <typename LocationT, typename AP>
+struct formatter<tacos::automata::ta::Transition<LocationT, AP>> : ostream_formatter
+{
+};
+
+template <typename LocationT, typename AP>
+struct formatter<tacos::automata::ta::TimedAutomaton<LocationT, AP>> : ostream_formatter
+{
+};
+
+} // namespace fmt
 
 #include "ta.hpp"
 

--- a/src/golog_adapter/include/golog_adapter/golog_adapter.h
+++ b/src/golog_adapter/include/golog_adapter/golog_adapter.h
@@ -13,6 +13,7 @@
 #include "search/canonical_word.h"
 #include "utilities/type_traits.h"
 
+#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
@@ -89,5 +90,14 @@ std::map<std::string, double> get_clock_values(const ClockSetValuation &clock_va
 } // namespace details
 
 } // namespace tacos::search
+
+namespace fmt {
+
+template <>
+struct formatter<tacos::search::GologLocation> : ostream_formatter
+{
+};
+
+} // namespace fmt
 
 #include "golog_adapter.hpp"

--- a/src/golog_app/app.cpp
+++ b/src/golog_app/app.cpp
@@ -139,7 +139,7 @@ Launcher::parse_command_line(int argc, const char *const argv[])
 	}
 
 	if (variables.count("help")) {
-		SPDLOG_INFO(options);
+		SPDLOG_INFO(fmt::streamed(options));
 		show_help = true;
 		return;
 	}

--- a/src/mtl/include/mtl/MTLFormula.h
+++ b/src/mtl/include/mtl/MTLFormula.h
@@ -6,12 +6,13 @@
  *  SPDX-License-Identifier: LGPL-3.0-or-later
  ****************************************************************************/
 
-
 #ifndef SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 #define SRC_MTL_INCLUDE_MTL_MTLFORMULA_H
 
 #include "utilities/Interval.h"
 #include "utilities/types.h"
+
+#include <fmt/ostream.h>
 
 #include <algorithm>
 #include <cassert>
@@ -315,7 +316,7 @@ private:
 
 	MTLFormula(LOP                               op,
 	           std::initializer_list<MTLFormula> operands,
-	           const TimeInterval &              duration = TimeInterval())
+	           const TimeInterval               &duration = TimeInterval())
 	: MTLFormula(op, std::begin(operands), std::end(operands), duration)
 	{
 	}
@@ -385,6 +386,20 @@ template <typename APType>
 std::ostream &operator<<(std::ostream &out, const logic::MTLFormula<APType> &f);
 
 } // namespace tacos::logic
+
+namespace fmt {
+
+template <typename APType>
+struct formatter<tacos::logic::AtomicProposition<APType>> : ostream_formatter
+{
+};
+
+template <typename APType>
+struct formatter<tacos::logic::MTLFormula<APType>> : ostream_formatter
+{
+};
+
+} // namespace fmt
 
 #include "MTLFormula.hpp"
 

--- a/src/search/include/search/canonical_word.h
+++ b/src/search/include/search/canonical_word.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "automata/ata.h"
+
+#include <fmt/ostream.h>
 // TODO Regions should not be TA-specific
 #include "automata/ta_regions.h"
 #include "mtl/MTLFormula.h"
@@ -538,3 +540,22 @@ operator<<(std::ostream                                                         
 }
 
 } // namespace tacos::search
+
+namespace fmt {
+
+template <typename LocationT>
+struct formatter<tacos::search::PlantRegionState<LocationT>> : ostream_formatter
+{
+};
+
+template <typename ConstraintSymbolType>
+struct formatter<tacos::search::ATARegionState<ConstraintSymbolType>> : ostream_formatter
+{
+};
+
+template <typename LocationT, typename ConstraintSymbolType>
+struct formatter<tacos::search::ABRegionSymbol<LocationT, ConstraintSymbolType>> : ostream_formatter
+{
+};
+
+} // namespace fmt

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(utilities INTERFACE)
-target_link_libraries(utilities INTERFACE automata tinyxml2 pthread)
+target_link_libraries(utilities INTERFACE automata tinyxml2 pthread fmt)
 target_include_directories(
   utilities INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/tacos>)

--- a/src/utilities/include/utilities/types.h
+++ b/src/utilities/include/utilities/types.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <fmt/ostream.h>
+
 #include <iostream>
 #include <map>
 #include <string>
@@ -124,3 +126,12 @@ operator<<(std::ostream &os, const PlantConfiguration<LocationT> &configuration)
 }
 
 } // namespace tacos
+
+namespace fmt {
+
+template <typename LocationT>
+struct formatter<tacos::PlantConfiguration<LocationT>> : ostream_formatter
+{
+};
+
+} // namespace fmt

--- a/src/visualization/include/visualization/interactive_tree_to_graphviz.h
+++ b/src/visualization/include/visualization/interactive_tree_to_graphviz.h
@@ -11,6 +11,7 @@
 #include "tree_to_graphviz.h"
 
 #include <fmt/ostream.h>
+#include <fmt/std.h>
 #include <search/search_tree.h>
 
 /// Visualization tools for automata and search trees.
@@ -146,3 +147,12 @@ search_tree_to_graphviz_interactive(
 }
 
 } // namespace tacos::visualization
+
+namespace fmt {
+
+template <>
+struct formatter<tacos::visualization::Mode> : ostream_formatter
+{
+};
+
+} // namespace fmt

--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -13,7 +13,7 @@ else()
   FetchContent_MakeAvailable(TinyXML2)
 endif()
 
-find_package(fmt QUIET)
+find_package(fmt 9 QUIET)
 if(fmt_FOUND)
   message(STATUS "Found fmt on system")
 else()
@@ -21,7 +21,8 @@ else()
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_SHALLOW TRUE)
+    GIT_SHALLOW TRUE
+    GIT_TAG 9.1.0)
   set(BUILD_SHARED_LIBS ON)
   FetchContent_MakeAvailable(fmt)
 endif()

--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -24,6 +24,7 @@ else()
     GIT_SHALLOW TRUE
     GIT_TAG 9.1.0)
   set(BUILD_SHARED_LIBS ON)
+  set(FMT_INSTALL ON)
   FetchContent_MakeAvailable(fmt)
 endif()
 


### PR DESCRIPTION
Starting with libfmt 9, libfmt no longer automatically uses ostream operators for formatting. Instead, a specialization of `fmt::ostream_formatter` is necessary. Provide all the necessary specializations.

This also requires libfmt9, because older versions do not have `fmt::ostream_formatter`.

This fixes #182.