### PR TITLE
third_party: upgrade to Catch2 v3.3.0

### DIFF
--- a/third_party/third_party.cmake
+++ b/third_party/third_party.cmake
@@ -70,10 +70,9 @@ else()
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.0.0-preview4
+    GIT_TAG v3.3.0
     GIT_SHALLOW TRUE)
   FetchContent_MakeAvailable(Catch2)
-  target_compile_options(Catch2 PRIVATE "-DCATCH_CONFIG_CONSOLE_WIDTH=200")
   list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 endif()
 include(Catch)


### PR DESCRIPTION
Also do not overwrite the output width. This is now a cmake cache variable, so each dev should set it on their own, e.g., with
```
cmake -B build -DCATCH_CONFIG_CONSOLE_WIDTH=200
```